### PR TITLE
chore(ci): stop waiting for tunnel when tunnen couldn't start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - BROWSER_STACK_USERNAME=angularteam1
   - BROWSER_STACK_ACCESS_KEY=BWCd4SynLzdDcv8xtzsB
   - BROWSER_PROVIDER_READY_FILE=/tmp/material-angular-io-build/readyfile
+  - BROWSER_PROVIDER_ERROR_FILE=/tmp/material-angular-io-build/errorfile
   matrix:
     - MODE=lint
     - MODE=e2e

--- a/scripts/browserstack/block-tunnel.sh
+++ b/scripts/browserstack/block-tunnel.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+TUNNEL_LOG="$LOGS_DIR/browserstack-tunnel.log"
 
 # Wait for Connect to be ready before exiting
 # Time out if we wait for more than 2 minutes, so the process won't run forever.
 let "counter=0"
+
+# Exit the process if there are errors reported. Print the tunnel log to the console.
+if [ -f $BROWSER_PROVIDER_ERROR_FILE ]; then
+  echo
+  echo "An error occurred while starting the tunnel. See error:"
+  cat $TUNNEL_LOG
+  exit 5
+fi
 
 while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
   let "counter++"

--- a/scripts/browserstack/start-tunnel.sh
+++ b/scripts/browserstack/start-tunnel.sh
@@ -56,6 +56,7 @@ function create_ready_file {
     tail -n0 -f $TUNNEL_LOG --pid $TIMER_PID | { sed '/Ctrl/q' && kill -9 $TIMER_PID; };
   } &> /dev/null
 
+  echo
   echo "BrowserStack Tunnel ready"
 
   touch $BROWSER_PROVIDER_READY_FILE

--- a/scripts/browserstack/start-tunnel.sh
+++ b/scripts/browserstack/start-tunnel.sh
@@ -16,10 +16,10 @@ touch $TUNNEL_LOG
 
 cd $TUNNEL_DIR
 
-# Download the saucelabs connect binaries.
+# Download the browserstack local binaries.
 curl $TUNNEL_URL -o $TUNNEL_FILE 2> /dev/null 1> /dev/null
 
-# Extract the saucelabs connect binaries from the tarball.
+# Extract the browserstack local binaries from the tarball.
 mkdir -p browserstack-tunnel
 unzip -q $TUNNEL_FILE -d browserstack-tunnel
 
@@ -43,7 +43,7 @@ function create_ready_file {
 
   # To be able to exit the tail properly we need to have a sub shell spawned, which is
   # used to track the state of tail.
-  sleep 120 &
+  { sleep 120; touch $BROWSER_PROVIDER_ERROR_FILE; } &
 
   TIMER_PID=$!
 


### PR DESCRIPTION
* When the tunnel didn't start properly after 2 minutes, the `block` script still waits 2 minutes until the timeout ends  (sum: 2 minutes unnecessary)

**Note**: This is the feedback from @jelbourn  and @hansl on `material2` 