### PR TITLE
Add missing examples, example titles, and ensure examples are destroyed

### DIFF
--- a/src/app/examples/chips-overview/chips-overview-example.html
+++ b/src/app/examples/chips-overview/chips-overview-example.html
@@ -1,0 +1,6 @@
+<md-chip-list>
+  <md-chip>One fish</md-chip>
+  <md-chip>Two fish</md-chip>
+  <md-chip color="primary" selected="true">Primary fish</md-chip>
+  <md-chip color="accent" selected="true">Accent fish</md-chip>
+</md-chip-list>

--- a/src/app/examples/chips-overview/chips-overview-example.ts
+++ b/src/app/examples/chips-overview/chips-overview-example.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'chips-overview-example',
+  templateUrl: './chips-overview-example.html',
+})
+export class ChipsOverviewExample {}

--- a/src/app/examples/chips-stacked/chips-stacked-example.css
+++ b/src/app/examples/chips-stacked/chips-stacked-example.css
@@ -1,0 +1,3 @@
+md-chip {
+  max-width: 200px;
+}

--- a/src/app/examples/chips-stacked/chips-stacked-example.html
+++ b/src/app/examples/chips-stacked/chips-stacked-example.html
@@ -1,0 +1,7 @@
+<md-chip-list class="md-chip-list-stacked">
+  <md-chip *ngFor="let chipColor of availableColors"
+      selected="true"
+      color="{{chipColor.color}}">
+    {{chipColor.name}}
+  </md-chip>
+</md-chip-list>

--- a/src/app/examples/chips-stacked/chips-stacked-example.ts
+++ b/src/app/examples/chips-stacked/chips-stacked-example.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'chips-stacked-example',
+  templateUrl: './chips-stacked-example.html',
+  styleUrls: ['./chips-stacked-example.css'],
+})
+export class ChipsStackedExample {
+  color: string;
+
+  availableColors = [
+    { name: 'none', color: '' },
+    { name: 'Primary', color: 'primary' },
+    { name: 'Accent', color: 'accent' },
+    { name: 'Warn', color: 'warn' }
+  ];
+}

--- a/src/app/examples/example-module.ts
+++ b/src/app/examples/example-module.ts
@@ -63,53 +63,75 @@ import {RadioOverviewExample} from './radio-overview/radio-overview-example';
 import {SidenavOverviewExample} from './sidenav-overview/sidenav-overview-example';
 
 
+export interface LiveExample {
+  title: string;
+  component: any;
+}
+
 /**
  * The list of example components.
  * Key is the example name which will be used in `material-docs-example="key"`.
  * Value is the component.
  */
-
 export const EXAMPLE_COMPONENTS = {
-  'button-overview': ButtonOverviewExample,
-  'button-types': ButtonTypesExample,
-  'button-toggle-exclusive': ButtonToggleExclusiveExample,
-  'button-toggle-overview': ButtonToggleOverviewExample,
-  'card-fancy': CardFancyExample,
-  'card-overview': CardOverviewExample,
-  'checkbox-configurable': CheckboxConfigurableExample,
-  'checkbox-overview': CheckboxOverviewExample,
-  'dialog-overview': DialogOverviewExample,
-  'dialog-result': DialogResultExample,
-  'grid-list-dynamic': GridListDynamicExample,
-  'grid-list-overview': GridListOverviewExample,
-  'icon-overview': IconOverviewExample,
-  'icon-svg': IconSvgExample,
-  'input-form': InputFormExample,
-  'input-overview': InputOverviewExample,
-  'list-overview': ListOverviewExample,
-  'list-sections': ListSectionsExample,
-  'menu-icons': MenuIconsExample,
-  'menu-overview': MenuOverviewExample,
-  'progress-bar-configurable': ProgressBarConfigurableExample,
-  'progress-bar-overview': ProgressBarOverviewExample,
-  'progress-spinner-configurable': ProgressSpinnerConfigurableExample,
-  'progress-spinner-overview': ProgressSpinnerOverviewExample,
-  'radio-ngmodel': RadioNgModelExample,
-  'radio-overview': RadioOverviewExample,
-  'sidenav-fab': SidenavFabExample,
-  'sidenav-overview': SidenavOverviewExample,
-  'slider-configurable': SliderConfigurableExample,
-  'slider-overview': SliderOverviewExample,
-  'slide-toggle-configurable': SlideToggleConfigurableExample,
-  'slide-toggle-overview': SlideToggleOverviewExample,
-  'snack-bar-component': SnackBarComponentExample,
-  'snack-bar-overview': SnackBarOverviewExample,
-  'tabs-overview': TabsOverviewExample,
-  'tabs-template-label': TabsTemplateLabelExample,
-  'toolbar-multirow': ToolbarMultirowExample,
-  'toolbar-overview': ToolbarOverviewExample,
-  'tooltip-overview': TooltipOverviewExample,
-  'tooltip-position': TooltipPositionExample,
+  'button-overview': {title: 'Basic buttons', component: ButtonOverviewExample},
+  'button-types': {title: 'Button varieties', component: ButtonTypesExample},
+  'button-toggle-exclusive': {
+    title: 'Exclusive selection',
+    component: ButtonToggleExclusiveExample
+  },
+  'button-toggle-overview': {title: 'Basic button-toggles', component: ButtonToggleOverviewExample},
+  'card-fancy': {title: 'Card with multiple sections', component: CardFancyExample},
+  'card-overview': {title: 'Basic cards', component: CardOverviewExample},
+  'checkbox-configurable': {title: 'Configurable checkbox', component: CheckboxConfigurableExample},
+  'checkbox-overview': {title: 'Basic checkboxes', component: CheckboxOverviewExample},
+  'dialog-overview': {title: 'Basic dialog', component: DialogOverviewExample},
+  'dialog-result': {title: 'Dailog with a result', component: DialogResultExample},
+  'grid-list-dynamic': {title: 'Dynamic grid-list', component: GridListDynamicExample},
+  'grid-list-overview': {title: 'Basic grid-list', component: GridListOverviewExample},
+  'icon-overview': {title: 'Basic icons', component: IconOverviewExample},
+  'icon-svg': {title: 'SVG icons', component: IconSvgExample},
+  'input-form': {title: 'Inputs in a form', component: InputFormExample},
+  'input-overview': {title: 'Basic inputs', component: InputOverviewExample},
+  'list-overview': {title: 'Basic list', component: ListOverviewExample},
+  'list-sections': {title: 'List with sections', component: ListSectionsExample},
+  'menu-icons': {title: 'Menu with icons', component: MenuIconsExample},
+  'menu-overview': {title: 'Basic menu', component: MenuOverviewExample},
+  'progress-bar-configurable': {
+    title: 'Configurable progress-bar',
+    component: ProgressBarConfigurableExample
+  },
+  'progress-bar-overview': {title: 'Basic progress-bar', component: ProgressBarOverviewExample},
+  'progress-spinner-configurable': {
+    title: 'Configurable progress-bar',
+    component: ProgressSpinnerConfigurableExample
+  },
+  'progress-spinner-overview': {
+    title: 'Basic progress-spinner',
+    component: ProgressSpinnerOverviewExample
+  },
+  'radio-ngmodel': {title: 'Radios with ngModel', component: RadioNgModelExample},
+  'radio-overview': {title: 'Basic radios', component: RadioOverviewExample},
+  'sidenav-fab': {title: 'Sidenav with a FAB', component: SidenavFabExample},
+  'sidenav-overview': {title: 'Basic sidenav', component: SidenavOverviewExample},
+  'slider-configurable': {title: 'Configurable slider', component: SliderConfigurableExample},
+  'slider-overview': {title: 'Basic slider', component: SliderOverviewExample},
+  'slide-toggle-configurable': {
+    title: 'Configurable slide-toggle',
+    component: SlideToggleConfigurableExample
+  },
+  'slide-toggle-overview': {title: 'Basic slide-toggles', component: SlideToggleOverviewExample},
+  'snack-bar-component': {
+    title: 'Snack-bar with a custom component',
+    component: SnackBarComponentExample
+  },
+  'snack-bar-overview': {title: 'Basic snack-bar', component: SnackBarOverviewExample},
+  'tabs-overview': {title: 'Basic tabs', component: TabsOverviewExample},
+  'tabs-template-label': {title: 'Tabs with a label template', component: TabsTemplateLabelExample},
+  'toolbar-multirow': {title: 'Multi-row toolbar', component: ToolbarMultirowExample},
+  'toolbar-overview': {title: 'basic toolbar', component: ToolbarOverviewExample},
+  'tooltip-overview': {title: 'Basic tooltip', component: TooltipOverviewExample},
+  'tooltip-position': {title: 'Tooltip with custom position', component: TooltipPositionExample},
 };
 
 /**

--- a/src/app/examples/example-module.ts
+++ b/src/app/examples/example-module.ts
@@ -61,6 +61,10 @@ import {
 import {TabsTemplateLabelExample} from './tabs-template-label/tabs-template-label-example';
 import {RadioOverviewExample} from './radio-overview/radio-overview-example';
 import {SidenavOverviewExample} from './sidenav-overview/sidenav-overview-example';
+import {SelectOverviewExample} from './select-overview/select-overview-example';
+import {ChipsOverviewExample} from './chips-overview/chips-overview-example';
+import {ChipsStackedExample} from './chips-stacked/chips-stacked-example';
+import {SelectFormExample} from './select-form/select-form-example';
 
 
 export interface LiveExample {
@@ -81,6 +85,8 @@ export const EXAMPLE_COMPONENTS = {
     component: ButtonToggleExclusiveExample
   },
   'button-toggle-overview': {title: 'Basic button-toggles', component: ButtonToggleOverviewExample},
+  'chips-overview': {title: 'Basic chips', component: ChipsOverviewExample},
+  'chips-stacked': {title: 'Stacked chips', component: ChipsStackedExample},
   'card-fancy': {title: 'Card with multiple sections', component: CardFancyExample},
   'card-overview': {title: 'Basic cards', component: CardOverviewExample},
   'checkbox-configurable': {title: 'Configurable checkbox', component: CheckboxConfigurableExample},
@@ -112,6 +118,8 @@ export const EXAMPLE_COMPONENTS = {
   },
   'radio-ngmodel': {title: 'Radios with ngModel', component: RadioNgModelExample},
   'radio-overview': {title: 'Basic radios', component: RadioOverviewExample},
+  'select-overview': {title: 'Basic select', component: SelectOverviewExample},
+  'select-form': {title: 'Select in a form', component: SelectFormExample},
   'sidenav-fab': {title: 'Sidenav with a FAB', component: SidenavFabExample},
   'sidenav-overview': {title: 'Basic sidenav', component: SidenavOverviewExample},
   'slider-configurable': {title: 'Configurable slider', component: SliderConfigurableExample},
@@ -145,6 +153,8 @@ export const EXAMPLE_LIST = [
   ButtonTypesExample,
   CardFancyExample,
   CardOverviewExample,
+  ChipsOverviewExample,
+  ChipsStackedExample,
   CheckboxConfigurableExample,
   CheckboxOverviewExample,
   DialogOverviewExample,
@@ -168,6 +178,8 @@ export const EXAMPLE_LIST = [
   RadioNgModelExample,
   RadioOverviewExample,
   SidenavFabExample,
+  SelectOverviewExample,
+  SelectFormExample,
   SidenavOverviewExample,
   SliderConfigurableExample,
   SliderOverviewExample,

--- a/src/app/examples/select-form/select-form-example.html
+++ b/src/app/examples/select-form/select-form-example.html
@@ -1,0 +1,9 @@
+<form>
+  <md-select placeholder="Favorite food" [(ngModel)]="selectedValue" name="food">
+    <md-option *ngFor="let food of foods" [value]="food.value">
+      {{food.viewValue}}
+    </md-option>
+  </md-select>
+
+  <p> Selected value: {{selectedValue}} </p>
+</form>

--- a/src/app/examples/select-form/select-form-example.ts
+++ b/src/app/examples/select-form/select-form-example.ts
@@ -1,0 +1,16 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'select-form-example',
+  templateUrl: './select-form-example.html',
+})
+export class SelectFormExample {
+  selectedValue: string;
+
+  foods = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos'}
+  ];
+}

--- a/src/app/examples/select-overview/select-overview-example.html
+++ b/src/app/examples/select-overview/select-overview-example.html
@@ -1,0 +1,5 @@
+<md-select placeholder="Favorite food">
+  <md-option *ngFor="let food of foods" [value]="food.value">
+    {{ food.viewValue }}
+  </md-option>
+</md-select>

--- a/src/app/examples/select-overview/select-overview-example.ts
+++ b/src/app/examples/select-overview/select-overview-example.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'select-overview-example',
+  templateUrl: './select-overview-example.html',
+})
+export class SelectOverviewExample {
+  foods = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos'}
+  ];
+}

--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -5,7 +5,8 @@ import {
   ComponentFactoryResolver,
   ViewContainerRef,
   ApplicationRef,
-  Injector
+  Injector,
+  OnDestroy,
 } from '@angular/core';
 import {Http} from '@angular/http';
 import {DomPortalHost, ComponentPortal} from '@angular/material';
@@ -16,7 +17,9 @@ import {ExampleViewer} from '../example-viewer/example-viewer';
   selector: 'doc-viewer',
   template: 'Loading document...',
 })
-export class DocViewer {
+export class DocViewer implements OnDestroy {
+  private _portalHosts: DomPortalHost[] = [];
+
   /** The URL of the document to display. */
   @Input()
   set documentUrl(url: string) {
@@ -61,6 +64,12 @@ export class DocViewer {
       let examplePortal = new ComponentPortal(ExampleViewer, this._viewContainerRef);
       let exampleViewer = portalHost.attach(examplePortal);
       exampleViewer.instance.example = example;
+
+      this._portalHosts.push(portalHost);
     });
+  }
+
+  ngOnDestroy() {
+    this._portalHosts.forEach(h => h.dispose());
   }
 }

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -21,7 +21,7 @@ const DOCS = [
       {id: 'checkbox', name: 'Checkbox', examples: ['checkbox-configurable']},
       {id: 'input', name: 'Input', examples: ['input-form']},
       {id: 'radio', name: 'Radio button', examples: ['radio-ngmodel']},
-      {id: 'select', name: 'Select', examples: []},
+      {id: 'select', name: 'Select', examples: ['select-form']},
       {id: 'slider', name: 'Slider', examples: ['slider-configurable']},
       {id: 'slide-toggle', name: 'Slide toggle', examples: ['slide-toggle-configurable']},
     ]
@@ -53,6 +53,7 @@ const DOCS = [
     items: [
       {id: 'button', name: 'Button', examples: ['button-types']},
       {id: 'button-toggle', name: 'Button toggle', examples: ['button-toggle-exclusive']},
+      {id: 'chips', name: 'Chips', examples: ['chips-stacked']},
       {id: 'icon', name: 'Icon', examples: ['icon-svg']},
       {id: 'progress-spinner', name: 'Progress spinner',
           examples: ['progress-spinner-configurable']},

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -18,12 +18,12 @@ const DOCS = [
     name: 'Form Controls',
     summary: 'Radio buttons, checkboxes, input fields, sliders, slide toggles, selects',
     items: [
-      {id: 'radio', name: 'Radio button', examples: ['radio-ngmodel']},
       {id: 'checkbox', name: 'Checkbox', examples: ['checkbox-configurable']},
       {id: 'input', name: 'Input', examples: ['input-form']},
+      {id: 'radio', name: 'Radio button', examples: ['radio-ngmodel']},
+      {id: 'select', name: 'Select', examples: []},
       {id: 'slider', name: 'Slider', examples: ['slider-configurable']},
       {id: 'slide-toggle', name: 'Slide toggle', examples: ['slide-toggle-configurable']},
-      {id: 'select', name: 'Select', examples: []},
     ]
   },
   {
@@ -31,9 +31,9 @@ const DOCS = [
     name: 'Navigation',
     summary: 'Sidenavs, toolbars, menus',
     items: [
+      {id: 'menu', name: 'Menu', examples: ['menu-icons']},
       {id: 'sidenav', name: 'Sidenav', examples: ['sidenav-fab']},
       {id: 'toolbar', name: 'Toolbar', examples: ['toolbar-multirow']},
-      {id: 'menu', name: 'Menu', examples: ['menu-icons']},
     ]
   },
   {
@@ -48,7 +48,7 @@ const DOCS = [
   },
   {
     id: 'buttons',
-    name: 'Buttons, Actions & Icons',
+    name: 'Buttons, Indicators & Icons',
     summary: 'buttons, button toggles, icons, progress spinners, progress bars',
     items: [
       {id: 'button', name: 'Button', examples: ['button-types']},

--- a/src/app/shared/example-viewer/example-viewer.html
+++ b/src/app/shared/example-viewer/example-viewer.html
@@ -1,6 +1,6 @@
 <div class="docs-example-viewer-wrapper">
   <div class="docs-example-viewer-title">
-    <div class="docs-example-viewer-title-spacer">{{exampleData.title}}</div>
+    <div class="docs-example-viewer-title-spacer">{{exampleData?.title}}</div>
 
     <button md-icon-button type="button" (click)="toggleSourceView()">
       <md-icon>

--- a/src/app/shared/example-viewer/example-viewer.html
+++ b/src/app/shared/example-viewer/example-viewer.html
@@ -1,6 +1,6 @@
 <div class="docs-example-viewer-wrapper">
   <div class="docs-example-viewer-title">
-    <div class="docs-example-viewer-title-spacer">{{example}}</div>
+    <div class="docs-example-viewer-title-spacer">{{exampleData.title}}</div>
 
     <button md-icon-button type="button" (click)="toggleSourceView()">
       <md-icon>

--- a/src/app/shared/example-viewer/example-viewer.scss
+++ b/src/app/shared/example-viewer/example-viewer.scss
@@ -21,5 +21,5 @@
 }
 
 .docs-example-viewer-body {
-  padding: 10px;
+  padding: 30px;
 }

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -38,6 +38,8 @@ export class ExampleViewer {
       this._example = example;
       this.exampleData = EXAMPLE_COMPONENTS[example];
       this.selectedPortal = new ComponentPortal(this.exampleData.component);
+    } else {
+      console.log('MISSING EXAMPLE: ', example);
     }
   }
 

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -3,7 +3,7 @@ import {Http} from '@angular/http';
 import {ComponentPortal} from '@angular/material';
 import 'rxjs/add/operator/first';
 
-import {EXAMPLE_COMPONENTS} from '../../examples/example-module';
+import {EXAMPLE_COMPONENTS, LiveExample} from '../../examples/example-module';
 
 
 @Component({
@@ -17,6 +17,8 @@ export class ExampleViewer {
 
   /** String key of the currently displayed example. */
   _example: string;
+
+  exampleData: LiveExample;
 
   /** Whether the source for the example is being displayed. */
   showSource: boolean = false;
@@ -34,7 +36,8 @@ export class ExampleViewer {
   set example(example: string) {
     if (example && EXAMPLE_COMPONENTS[example]) {
       this._example = example;
-      this.selectedPortal = new ComponentPortal(EXAMPLE_COMPONENTS[example]);
+      this.exampleData = EXAMPLE_COMPONENTS[example];
+      this.selectedPortal = new ComponentPortal(this.exampleData.component);
     }
   }
 

--- a/src/assets/documents/overview/button-toggle.html
+++ b/src/assets/documents/overview/button-toggle.html
@@ -1,6 +1,6 @@
-<p>Button-toggles are on/off toggles with the appearance of a button. These toggles can be configured
-to behave as either radio-buttons or checkboxes. While they can be standalone, they are typically 
-part of a <code>md-button-toggle-group</code>.</p>
+<p><code>&lt;md-button-toggle&gt;</code> are on/off toggles with the appearance of a button. These toggles can be 
+configured to behave as either radio-buttons or checkboxes. While they can be standalone, they are 
+typically part of a <code>md-button-toggle-group</code>.</p>
 <div material-docs-example="button-toggle-overview"></div>
 <h3 id="exclusive-selection-vs-multiple-selection">Exclusive selection vs. multiple selection</h3>
 <p>By default, <code>md-button-toggle-group</code> acts like a radio-button group- only one item can be selected.

--- a/src/assets/documents/overview/card.html
+++ b/src/assets/documents/overview/card.html
@@ -1,4 +1,4 @@
-<p>Cards are content containers for text, photos, and actions. Cards are intended to provide 
+<p><code>&lt;md-card&gt;</code> is a content container for text, photos, and actions. Cards are intended to provide 
 information on a single subject.</p>
 <div material-docs-example="card-overview"></div>
 <h3 id="basic-card-sections">Basic card sections</h3>

--- a/src/assets/documents/overview/checkbox.html
+++ b/src/assets/documents/overview/checkbox.html
@@ -1,5 +1,5 @@
 <p><code>&lt;md-checkbox&gt;</code> provides the same functionality as a native <code>&lt;input type=&quot;checkbox&quot;&gt;</code>
-enhanced Material Design styling and animations.</p>
+enhanced with Material Design styling and animations.</p>
 <div material-docs-example="checkbox-overview"></div>
 <h3 id="checkbox-label">Checkbox label</h3>
 <p>The checkbox label is provided as the content to the <code>&lt;md-checkbox&gt;</code> element. The label can be 

--- a/src/assets/documents/overview/chips.html
+++ b/src/assets/documents/overview/chips.html
@@ -1,5 +1,21 @@
-<h1 id="md-chips">md-chips</h1>
-<p><code>md-chips</code> provides a horizontal display of (optionally) selectable, addable, and removable,
-items and an input to create additional ones (again; optional). You can read more about chips
-in the <a href="https://material.google.com/components/chips.html">Material Design spec</a>.</p>
-<p>This is a placeholder README for the eventual chips component.</p>
+<p><code>&lt;md-chip-list&gt;</code> displays a list of values as individual chips.</p>
+<div material-docs-example="chips-overview"></div>
+<p><em>Note: chips are still early in their development and more features are being actively worked on.</em></p>
+<pre><code class="lang-html">&lt;md-chip-list&gt;
+  &lt;md-chip&gt;Papadum&lt;/md-chip&gt;
+  &lt;md-chip&gt;Naan&lt;/md-chip&gt;
+  &lt;md-chip&gt;Dal&lt;/md-chip&gt;
+&lt;/md-chip-list&gt;
+</code></pre>
+<h3 id="unstyled-chips">Unstyled chips</h3>
+<p>By default, <code>&lt;md-chip&gt;</code> has Material Design styles applied. For a chip with no styles applied,
+use <code>&lt;md-basic-chip&gt;</code>. You can then customize the chip appearance by adding your own CSS.</p>
+<h3 id="selection">Selection</h3>
+<p>Chips can be selected via the <code>selected</code> property. Selection can be disabled by setting
+<code>selectable</code> to <code>false</code> on the <code>&lt;md-chip-list&gt;</code>. </p>
+<h3 id="keyboard-interation">Keyboard interation</h3>
+<p>Users can move through the chips using the arrow keys and select them with the space.</p>
+<h3 id="theming">Theming</h3>
+<p>The color of an <code>&lt;md-chip&gt;</code> can be changed by using the <code>color</code> property. By default, chips
+use a neutral background color based on the current theme (light or dark). This can be changed to 
+<code>&#39;primary&#39;</code>, <code>&#39;accent&#39;</code>, or <code>&#39;warn&#39;</code>.</p>

--- a/src/assets/documents/overview/grid-list.html
+++ b/src/assets/documents/overview/grid-list.html
@@ -1,8 +1,6 @@
-<h1 id="md-grid-list">md-grid-list</h1>
-<p><code>md-grid-list</code> is an alternative list view that arranges cells into grid-based layout. 
+<p><code>md-grid-list</code> is a two-dimensional list view that arranges cells into grid-based layout. 
 See Material Design spec <a href="https://www.google.com/design/spec/components/grid-lists.html">here</a>.</p>
 <div material-docs-example="grid-list-overview"></div>
-<h2 id="usage">Usage</h2>
 <h3 id="setting-the-number-of-columns">Setting the number of columns</h3>
 <p>An <code>md-grid-list</code> must specify a <code>cols</code> attribute which sets the number of columns in the gird. The
 number of rows will be automatically determined based on the number of columns and the number of

--- a/src/assets/documents/overview/icon.html
+++ b/src/assets/documents/overview/icon.html
@@ -1,15 +1,10 @@
-<h1 id="md-icon">md-icon</h1>
 <p><code>md-icon</code> makes it easier to use <em>vector-based</em> icons in your app.  This directive supports both
 icon fonts and SVG icons, but not bitmap-based formats (png, jpg, etc.).</p>
 <div material-docs-example="icon-example"></div>
-<h2 id="usage">Usage</h2>
-<h3 id="registering-new-icons">Registering new icons</h3>
+<h3 id="registering-icons">Registering icons</h3>
 <p><code>MdIconRegistry</code> is an injectable service that allows you to associate icon names with SVG URLs and
 define aliases for CSS font classes. Its methods are discussed below and listed in the API summary.</p>
-<p>In order to prevent XSS vulnerabilities, any URLs passed to the <code>MdIconRegistry</code> must be marked as
-trusted resource URLs by using Angular&#39;s <code>DomSanitizer</code> service.</p>
-<h3 id="font-icons">Font icons</h3>
-<h4 id="ligatures">Ligatures</h4>
+<h3 id="font-icons-with-ligatures">Font icons with ligatures</h3>
 <p>Some fonts are designed to show icons by using
 <a href="https://en.wikipedia.org/wiki/Typographic_ligature">ligatures</a>, for example by rendering the text
 &quot;home&quot; as a home image. To use a ligature icon, put its text in the content of the <code>md-icon</code>
@@ -20,7 +15,7 @@ component.</p>
 You can specify a different font by setting the <code>fontSet</code> input to either the CSS class to apply to
 use the desired font, or to an alias previously registered with
 <code>MdIconRegistry.registerFontClassAlias</code>.</p>
-<h4 id="font-icons-via-css">Font icons via CSS</h4>
+<h3 id="font-icons-with-css">Font icons with CSS</h3>
 <p>Fonts can also display icons by defining a CSS class for each icon glyph, which typically uses a
 <code>:before</code> selector to cause the icon to appear.
 <a href="https://fortawesome.github.io/Font-Awesome/examples/">FontAwesome</a> uses this approach to display
@@ -33,12 +28,15 @@ explicitly set by calling <code>MdIconRegistry.setDefaultFontSetClass</code>.</p
 <p>When an <code>md-icon</code> component displays an SVG icon, it does so by directly inlining the SVG content
 into the page as a child of the component. (Rather than using an <img> tag or a div background
 image). This makes it easier to apply CSS styles to SVG icons. For example, the default color of the
-SVG content is the CSS <a href="http://www.quirksmode.org/css/color/currentcolor.html">currentColor</a> value.
-This makes SVG icons by default have the same color as surrounding text, and allows you to change
-the color by setting the &quot;color&quot; style on the <code>md-icon</code> element.</p>
-<h4 id="icons-from-urls">Icons from URLs</h4>
-<p>SVG icons can be used either by directly specifying the icon&#39;s URL, or by associating an icon name
-with a URL and then referring to the name. To use a URL directly, set the <code>svgSrc</code> input.</p>
+SVG content is the CSS 
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentColor_keyword">currentColor</a> 
+value. This makes SVG icons by default have the same color as surrounding text, and allows you to 
+change the color by setting the &quot;color&quot; style on the <code>md-icon</code> element.</p>
+<p>In order to prevent XSS vulnerabilities, any SVG URLs passed to the <code>MdIconRegistry</code> must be 
+marked as trusted resource URLs by using Angular&#39;s <code>DomSanitizer</code> service.</p>
+<p>Also note that all SVG icons are fetched via XmlHttpRequest, and due to the same-origin policy, 
+their URLs must be on the same domain as the containing page, or their servers must be configured 
+to allow cross-domain access.</p>
 <h4 id="named-icons">Named icons</h4>
 <p>To associate a name with an icon URL, use the <code>addSvgIcon</code> or <code>addSvgIconInNamespace</code> methods of
 <code>MdIconRegistry</code>. After registering an icon, it can be displayed by setting the <code>svgIcon</code> input.
@@ -54,12 +52,10 @@ their <code>id</code> attributes. To display an icon from an icon set, use the <
 as for individually registered icons.</p>
 <p>Multiple icon sets can be registered in the same namespace. Requesting an icon whose id appears in
 more than one icon set, the icon from the most recently registered set will be used.</p>
-<p>Note that all SVG icons are fetched via XmlHttpRequest, and due to the same-origin policy their URLs
-must be on the same domain as the containing page, or their servers must be configured to allow
-cross-domain access.</p>
 <h3 id="theming">Theming</h3>
-<p>Icons can be themed to match your &quot;primary&quot; palette, your &quot;accent&quot; palette, or your &quot;warn&quot; palette
-using the <code>color</code> attribute. Simply pass in the desired palette name.</p>
+<p>By default, icons will use the current font color (<code>currentColor</code>). this color can be changed to 
+match the current theme&#39;s colors using the <code>color</code> attribute. This can be changed to 
+<code>&#39;primary&#39;</code>, <code>&#39;accent&#39;</code>, or <code>&#39;warn&#39;</code>.</p>
 <h3 id="accessibility">Accessibility</h3>
 <p>If an <code>aria-label</code> attribute is set on the <code>md-icon</code> element, its value will be used as-is. If not,
 the md-icon component will attempt to set the aria-label value from one of these sources:</p>

--- a/src/assets/documents/overview/input.html
+++ b/src/assets/documents/overview/input.html
@@ -1,21 +1,18 @@
-<h1 id="md-input-container">md-input-container</h1>
-<p>Inputs are the basic input component of Material 2. The spec can be found
-<a href="https://www.google.com/design/spec/components/text-fields.html">here</a>. <code>md-input-container</code> acts as
-a wrapper for native <code>input</code> and <code>textarea</code> elements that is used to add material design styles and
-behavior. The native element wrapped by the <code>md-input-container</code> must be marked with the <code>md-input</code>
-directive.</p>
+<p><code>&lt;md-input-container&gt;</code> is a wrapper for native <code>input</code> and <code>textarea</code> elements. This container 
+applies Material Design styles and behavior while still allowing direct access to the underlying
+native element.</p>
+<p>The native element wrapped by the <code>md-input-container</code> must be marked with the <code>mdInput</code> directive.</p>
 <div material-docs-example="input-overview"></div>
-<h2 id="usage">Usage</h2>
 <h3 id="-input-and-textarea-attributes"><code>input</code> and <code>textarea</code> attributes</h3>
 <p>All of the attributes that can be used with normal <code>input</code> and <code>textarea</code> elements can be used on
-elements within the <code>md-input-container</code> as well. This includes angular specific ones such as
+elements inside <code>md-input-container</code> as well. This includes Angular directives such as
 <code>ngModel</code> and <code>formControl</code>.</p>
 <p>The only limitations are that the <code>type</code> attribute can only be one of the values supported by
 <code>md-input-container</code> and the native element cannot specify a <code>placeholder</code> attribute if the
 <code>md-input-container</code> also contains a <code>md-placeholder</code> element. </p>
-<h4 id="supported-input-types">Supported <code>input</code> types</h4>
-<p>The following <a href="http://www.w3schools.com/TAGs/att_input_type.asp">input types</a> can be used with
-<code>md-input-container</code>:</p>
+<h3 id="supported-input-types">Supported <code>input</code> types</h3>
+<p>The following <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input">input types</a> can
+be used with <code>md-input-container</code>:</p>
 <ul>
 <li>date</li>
 <li>datetime-local</li>

--- a/src/assets/documents/overview/list.html
+++ b/src/assets/documents/overview/list.html
@@ -1,28 +1,43 @@
-<h1 id="md-list">md-list</h1>
-<p><code>md-list</code> is a container component that wraps and formats a series of line items. As the base list component,
- it provides Material Design styling, but no behavior of its own.</p>
-<h2 id="usage">Usage</h2>
-<h3 id="simple-list">Simple list</h3>
-<p>In your template, create an <code>md-list</code> element and wrap each of your items in an <code>md-list-item</code> tag.</p>
+<p><code>&lt;md-list&gt;</code> is a container component that wraps and formats a series of line items. As the base 
+list component, it provides Material Design styling, but no behavior of its own.</p>
+<div material-docs-example="list-overview"></div>
+<h3 id="simple-lists">Simple lists</h3>
+<p>An <code>&lt;md-list&gt;</code> element contains a number of <code>&lt;md-list-item&gt;</code> elements.</p>
 <pre><code class="lang-html">&lt;md-list&gt;
-   &lt;md-list-item&gt; Pepper &lt;/md-list-item&gt;
-   &lt;md-list-item&gt; Salt &lt;/md-list-item&gt;
-   &lt;md-list-item&gt; Paprika &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Pepper &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Salt &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Paprika &lt;/md-list-item&gt;
 &lt;/md-list&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/basic-list.png"></p>
+<h3 id="navigation-lists">Navigation lists</h3>
+<p>Use <code>md-nav-list</code> tags for navigation lists (i.e. lists that have anchor tags).</p>
+<p>Simple navigation lists can use the <code>md-list-item</code> attribute on anchor tag elements directly:</p>
+<pre><code class="lang-html">&lt;md-nav-list&gt;
+   &lt;a md-list-item href=&quot;...&quot; *ngFor=&quot;let link of links&quot;&gt; {{ link }} &lt;/a&gt;
+&lt;/md-nav-list&gt;
+</code></pre>
+<p>For more complex navigation lists (e.g. with more than one target per item), wrap the anchor 
+element in an <code>&lt;md-list-item&gt;</code>.</p>
+<pre><code class="lang-html">&lt;md-nav-list&gt;
+  &lt;md-list-item *ngFor=&quot;let link of links&quot;&gt;
+     &lt;a md-line href=&quot;...&quot;&gt;{{ link }}&lt;/a&gt;
+     &lt;button md-icon-button (click)=&quot;showInfo(link)&quot;&gt;
+        &lt;md-icon&gt;info&lt;/md-icon&gt;
+     &lt;/button&gt;
+  &lt;/md-list-item&gt;
+&lt;/md-nav-list&gt;
+</code></pre>
 <h3 id="multi-line-lists">Multi-line lists</h3>
-<p>If your list requires multiple lines per list item, annotate each line with an <code>md-line</code> attribute.
-You can use whichever heading tag is appropriate for your DOM hierarchy (doesn&#39;t have to be <code>h3</code>),
-as long as the <code>md-line</code> attribute is included.</p>
+<p>For lists that require multiple lines per item, annotate each line with an <code>md-line</code> attribute.
+Whichever heading tag is appropriate for your DOM hierarchy should be used (not necesarily <code>&lt;h3&gt;</code>
+as shown in the example).</p>
 <pre><code class="lang-html">&lt;!-- two line list --&gt;
 &lt;md-list&gt;
   &lt;md-list-item *ngFor=&quot;let message of messages&quot;&gt;
     &lt;h3 md-line&gt; {{message.from}} &lt;/h3&gt;
     &lt;p md-line&gt;
       &lt;span&gt; {{message.subject}} &lt;/span&gt;
-      &lt;span class=&quot;demo-2&quot;&gt; -- {{message.message}} &lt;/span&gt;
+      &lt;span class=&quot;demo-2&quot;&gt; -- {{message.content}} &lt;/span&gt;
     &lt;/p&gt;
   &lt;/md-list-item&gt;
 &lt;/md-list&gt;
@@ -32,14 +47,10 @@ as long as the <code>md-line</code> attribute is included.</p>
   &lt;md-list-item *ngFor=&quot;let message of messages&quot;&gt;
     &lt;h3 md-line&gt; {{message.from}} &lt;/h3&gt;
     &lt;p md-line&gt; {{message.subject}} &lt;/p&gt;
-    &lt;p md-line class=&quot;demo-2&quot;&gt; {{message.message}} &lt;/p&gt;
+    &lt;p md-line class=&quot;demo-2&quot;&gt; {{message.content}} &lt;/p&gt;
   &lt;/md-list-item&gt;
 &lt;/md-list&gt;
 </code></pre>
-<p>Two line list output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/two-line-list.png"></p>
-<p>Three line list output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/three-line-list.png"></p>
 <h3 id="lists-with-avatars">Lists with avatars</h3>
 <p>To include an avatar, add an image tag with an <code>md-list-avatar</code> attribute.</p>
 <pre><code class="lang-html">&lt;md-list&gt;
@@ -48,28 +59,24 @@ as long as the <code>md-line</code> attribute is included.</p>
     &lt;h3 md-line&gt; {{message.from}} &lt;/h3&gt;
     &lt;p md-line&gt;
       &lt;span&gt; {{message.subject}} &lt;/span&gt;
-      &lt;span class=&quot;demo-2&quot;&gt; -- {{message.message}} &lt;/span&gt;
+      &lt;span class=&quot;demo-2&quot;&gt; -- {{message.content}} &lt;/span&gt;
     &lt;/p&gt;
   &lt;/md-list-item&gt;
 &lt;/md-list&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/list-with-avatar-2.png"></p>
 <h3 id="dense-lists">Dense lists</h3>
 <p>Lists are also available in &quot;dense layout&quot; mode, which shrinks the font size and height of the list
-to suit UIs that may need to display more information.  To enable this mode, add a <code>dense</code> attribute
+to suit UIs that may need to display more information. To enable this mode, add a <code>dense</code> attribute
 to the main <code>md-list</code> tag.</p>
 <pre><code class="lang-html">&lt;md-list dense&gt;
-   &lt;md-list-item&gt; Pepper &lt;/md-list-item&gt;
-   &lt;md-list-item&gt; Salt &lt;/md-list-item&gt;
-   &lt;md-list-item&gt; Paprika &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Pepper &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Salt &lt;/md-list-item&gt;
+ &lt;md-list-item&gt; Paprika &lt;/md-list-item&gt;
 &lt;/md-list&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/dense-list.png"></p>
 <h3 id="lists-with-multiple-sections">Lists with multiple sections</h3>
-<p>You can add a subheader to a list by annotating a heading tag with an <code>md-subheader</code> attribute. To add a divider,
-use <code>&lt;md-divider&gt;</code> tags.</p>
+<p>Subheader can be added to a list by annotating a heading tag with an <code>md-subheader</code> attribute. 
+To add a divider, use <code>&lt;md-divider&gt;</code>.</p>
 <pre><code class="lang-html">&lt;md-list&gt;
    &lt;h3 md-subheader&gt;Folders&lt;/h3&gt;
    &lt;md-list-item *ngFor=&quot;let folder of folders&quot;&gt;
@@ -86,26 +93,3 @@ use <code>&lt;md-divider&gt;</code> tags.</p>
    &lt;/md-list-item&gt;
 &lt;/md-list&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/list/subheader-list.png"></p>
-<h3 id="navigation-lists">Navigation lists</h3>
-<p>Use <code>md-nav-list</code> tags for navigation lists (i.e. lists that have anchor tags).</p>
-<p>Simple nav lists can tack an <code>md-list-item</code> attribute onto the anchor tag itself:</p>
-<pre><code class="lang-html">&lt;md-nav-list&gt;
-   &lt;a md-list-item href=&quot;...&quot; *ngFor=&quot;let link of links&quot;&gt; {{ link }} &lt;/a&gt;
-&lt;/md-nav-list&gt;
-</code></pre>
-<p>If you require a more complex nav list (e.g. with more than one target per item), wrap your anchor tag in an <code>md-list-item</code> element.</p>
-<pre><code class="lang-html">&lt;md-nav-list&gt;
-  &lt;md-list-item *ngFor=&quot;let link of links&quot;&gt;
-     &lt;a md-line href=&quot;...&quot;&gt;{{ link }}&lt;/a&gt;
-     &lt;button md-icon-button (click)=&quot;showInfo(link)&quot;&gt;
-        &lt;md-icon&gt;info&lt;/md-icon&gt;
-     &lt;/button&gt;
-  &lt;/md-list-item&gt;
-&lt;/md-nav-list&gt;
-</code></pre>
-<h3 id="lists-with-secondary-text">Lists with secondary text</h3>
-<p>Secondary text styling will be part of a broader typography module to
-<a href="https://github.com/angular/material2/issues/205">come later</a>, and won’t be implemented as part of this component
-specifically. Gray text in the examples above comes from a &quot;demo-2&quot; class added manually by the demo.</p>

--- a/src/assets/documents/overview/menu.html
+++ b/src/assets/documents/overview/menu.html
@@ -1,52 +1,20 @@
-<h1 id="md-menu">md-menu</h1>
-<p><code>md-menu</code> is a list of options that displays when triggered.  You can read more about menus in the
-<a href="https://material.google.com/components/menus.html">Material Design spec</a>.</p>
-<h3 id="not-yet-implemented">Not yet implemented</h3>
-<ul>
-<li><code>prevent-close</code> option, to turn off automatic menu close when clicking outside the menu</li>
-<li>Custom offset support</li>
-<li>Menu groupings (which menus are allowed to open together)</li>
-</ul>
-<h2 id="usage">Usage</h2>
-<h3 id="simple-menu">Simple menu</h3>
-<p>In your template, create an <code>md-menu</code> element. You can use either <code>&lt;button&gt;</code> or <code>&lt;anchor&gt;</code> tags for
-your menu items, as long as each is tagged with an <code>md-menu-item</code> attribute. Note that you can
-disable items by adding the <code>disabled</code> boolean attribute or binding to it.</p>
-<p><em>my-comp.html</em></p>
-<pre><code class="lang-html">&lt;!-- this menu starts as hidden by default --&gt;
-&lt;md-menu&gt;
-    &lt;button md-menu-item&gt; Refresh &lt;/button&gt;
-    &lt;button md-menu-item&gt; Settings &lt;/button&gt;
-    &lt;button md-menu-item&gt; Help &lt;/button&gt;
-    &lt;button md-menu-item disabled&gt; Sign Out &lt;/button&gt;
+<p><code>&lt;md-menu&gt;</code> is a floating panel containing list of options. </p>
+<div material-docs-example="menu-overview"></div>
+<p>By itself, the <code>&lt;md-menu&gt;</code> element does not render anything. The menu is attached to and opened 
+via application of the <code>mdMenuTriggerFor</code> directive:</p>
+<pre><code class="lang-ts">&lt;md-menu #appMenu=&quot;mdMenu&quot;&gt;
+  &lt;button md-menu-item&gt; Settings &lt;/button&gt;
+  &lt;button md-menu-item&gt; Help &lt;/button&gt;
 &lt;/md-menu&gt;
-</code></pre>
-<p>Menus are hidden by default, so you&#39;ll want to connect up a menu trigger that can open your menu.
-You can do so by adding a button tag with an <code>mdMenuTriggerFor</code> attribute and passing in the menu
-instance.  You can create a local reference to your menu instance by adding <code>#menu=&quot;mdMenu&quot;</code> to
-your menu element.</p>
-<p><em>my-comp.html</em></p>
-<pre><code class="lang-html">&lt;!-- menu opens when trigger button is clicked --&gt;
-&lt;button md-icon-button [mdMenuTriggerFor]=&quot;menu&quot;&gt;
+
+&lt;button md-icon-button [mdMenuTriggerFor]=&quot;appMenu&quot;&gt;
    &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
 &lt;/button&gt;
-
-&lt;md-menu #menu=&quot;mdMenu&quot;&gt;
-    &lt;button md-menu-item&gt; Refresh &lt;/button&gt;
-    &lt;button md-menu-item&gt; Settings &lt;/button&gt;
-    &lt;button md-menu-item&gt; Help &lt;/button&gt;
-    &lt;button md-menu-item disabled&gt; Sign Out &lt;/button&gt;
-&lt;/md-menu&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/menu/default_closed.png">
-<img src="https://material.angularjs.org/material2_assets/menu/default_open.png"></p>
 <h3 id="toggling-the-menu-programmatically">Toggling the menu programmatically</h3>
-<p>You can also use the menu&#39;s API to open or close the menu programmatically from your class. Please
-note that in this case, an <code>mdMenuTriggerFor</code> attribute is still necessary to connect
-the menu to its trigger element in the DOM.</p>
-<p><em>my-comp.component.ts</em></p>
-<pre><code class="lang-ts">class MyComp {
+<p>The menu exposes an API to open/close programmatically. Please note that in this case, an 
+<code>mdMenuTriggerFor</code> directive is still necessary to attach the menu to a trigger element in the DOM.</p>
+<pre><code class="lang-ts">class MyComponent {
   @ViewChild(MdMenuTrigger) trigger: MdMenuTrigger;
 
   someMethod() {
@@ -54,20 +22,8 @@ the menu to its trigger element in the DOM.</p>
   }
 }
 </code></pre>
-<p><em>my-comp.html</em></p>
-<pre><code class="lang-html">&lt;button md-icon-button [mdMenuTriggerFor]=&quot;menu&quot;&gt;
-   &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
-&lt;/button&gt;
-
-&lt;md-menu #menu=&quot;mdMenu&quot;&gt;
-    &lt;button md-menu-item&gt; Refresh &lt;/button&gt;
-    &lt;button md-menu-item&gt; Settings &lt;/button&gt;
-    &lt;button md-menu-item&gt; Help &lt;/button&gt;
-    &lt;button md-menu-item disabled&gt; Sign Out &lt;/button&gt;
-&lt;/md-menu&gt;
-</code></pre>
-<h3 id="adding-an-icon">Adding an icon</h3>
-<p>Menus also support displaying <code>md-icon</code> elements before the menu item text.</p>
+<h3 id="icons">Icons</h3>
+<p>Menus support displaying <code>md-icon</code> elements before the menu item text.</p>
 <p><em>my-comp.html</em></p>
 <pre><code class="lang-html">&lt;md-menu #menu=&quot;mdMenu&quot;&gt;
   &lt;button md-menu-item&gt;
@@ -84,113 +40,12 @@ the menu to its trigger element in the DOM.</p>
   &lt;/button&gt;
 &lt;/md-menu&gt;
 </code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/menu/icon_menu_closed.png">
-<img src="https://material.angularjs.org/material2_assets/menu/icon_menu_open.png"></p>
 <h3 id="customizing-menu-position">Customizing menu position</h3>
-<p>By default, the menu will display after and below its trigger.  You can change this display position
+<p>By default, the menu will display after and below its trigger.  The position can be changed
 using the <code>x-position</code> (<code>before | after</code>) and <code>y-position</code> (<code>above | below</code>) attributes.</p>
-<p><em>my-comp.html</em></p>
-<pre><code class="lang-html">&lt;md-menu x-position=&quot;before&quot; #menu=&quot;mdMenu&quot;&gt;
-    &lt;button md-menu-item&gt; Refresh &lt;/button&gt;
-    &lt;button md-menu-item&gt; Settings &lt;/button&gt;
-    &lt;button md-menu-item&gt; Help &lt;/button&gt;
-    &lt;button md-menu-item disabled&gt; Sign Out &lt;/button&gt;
-&lt;/md-menu&gt;
-</code></pre>
-<p>Output:</p>
-<p><img src="https://material.angularjs.org/material2_assets/menu/before_closed.png">
-<img src="https://material.angularjs.org/material2_assets/menu/before_open.png"></p>
-<h3 id="accessibility">Accessibility</h3>
-<p>The menu adds <code>role=&quot;menu&quot;</code> to the main menu element and <code>role=&quot;menuitem&quot;</code> to each menu item. It
-also adds <code>aria-hasPopup=&quot;true&quot;</code> to the trigger element.</p>
-<h4 id="keyboard-events-">Keyboard events:</h4>
+<h3 id="keyboard-interaction">Keyboard interaction</h3>
 <ul>
-<li><kbd>DOWN_ARROW</kbd>: Focus next menu item</li>
-<li><kbd>UP_ARROW</kbd>: Focus previous menu item</li>
-<li><kbd>ENTER</kbd>: Select focused item</li>
+<li><kbd>DOWN_ARROW</kbd>: Focuses the next menu item</li>
+<li><kbd>UP_ARROW</kbd>: Focuses previous menu item</li>
+<li><kbd>ENTER</kbd>: Activates the focused menu item</li>
 </ul>
-<h3 id="menu-attributes">Menu attributes</h3>
-<table>
-<thead>
-<tr>
-<th>Signature</th>
-<th>Values</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>x-position</code></td>
-<td>`before</td>
-<td>after`</td>
-<td>The horizontal position of the menu in relation to the trigger. Defaults to <code>after</code>.</td>
-</tr>
-<tr>
-<td><code>y-position</code></td>
-<td>`above</td>
-<td>below`</td>
-<td>The vertical position of the menu in relation to the trigger. Defaults to <code>below</code>.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="trigger-programmatic-api">Trigger Programmatic API</h3>
-<p><strong>Properties</strong></p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>menuOpen</code></td>
-<td><code>Boolean</code></td>
-<td>Property that is true when the menu is open. It is not settable (use methods below).</td>
-</tr>
-<tr>
-<td><code>onMenuOpen</code></td>
-<td><code>Observable&lt;void&gt;</code></td>
-<td>Observable that emits when the menu opens.</td>
-</tr>
-<tr>
-<td><code>onMenuClose</code></td>
-<td><code>Observable&lt;void&gt;</code></td>
-<td>Observable that emits when the menu closes.</td>
-</tr>
-</tbody>
-</table>
-<p><strong>Methods</strong></p>
-<table>
-<thead>
-<tr>
-<th>Method</th>
-<th>Returns</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>openMenu()</code></td>
-<td><code>Promise&lt;void&gt;</code></td>
-<td>Opens the menu. Returns a promise that will resolve when the menu has opened.</td>
-</tr>
-<tr>
-<td><code>closeMenu()</code></td>
-<td><code>Promise&lt;void&gt;</code></td>
-<td>Closes the menu. Returns a promise that will resolve when the menu has closed.</td>
-</tr>
-<tr>
-<td><code>toggleMenu()</code></td>
-<td><code>Promise&lt;void&gt;</code></td>
-<td>Toggles the menu. Returns a promise that will resolve when the menu has completed opening or closing.</td>
-</tr>
-<tr>
-<td><code>destroyMenu()</code></td>
-<td><code>Promise&lt;void&gt;</code></td>
-<td>Destroys the menu overlay completely.</td>
-</tr>
-</tbody>
-</table>

--- a/src/assets/documents/overview/progress-bar.html
+++ b/src/assets/documents/overview/progress-bar.html
@@ -1,78 +1,40 @@
-<h1 id="md-progress-bar">md-progress-bar</h1>
-<p><code>md-progress-bar</code> is a component for indicating progress and activity, matching the spec of 
-<a href="https://www.google.com/design/spec/components/progress-activity.html">Material Design Progress &amp; Activity</a>.</p>
-<h3 id="progress-modes">Progress Modes</h3>
-<p>There are four modes:</p>
-<ol>
-<li>Determinate - <code>&lt;md-progress-bar mode=&quot;determinate&quot;&gt;</code><ul>
-<li>Indicates how long an operation will take when the percentage complete is detectable. </li>
-</ul>
-</li>
-<li>Indeterminate - <code>&lt;md-progress-bar mode=&quot;indeterminate&quot;&gt;</code><ul>
-<li>Indicates the user must wait while something finishes when it’s not necessary or possible to indicate how long it will take.</li>
-</ul>
-</li>
-<li>Buffer - <code>&lt;md-progress-bar mode=&quot;buffer&quot;&gt;</code><ul>
-<li>Indicates how long an operation will take when the percentage complete is detectable, also provides a value of the preloading for the operation.</li>
-</ul>
-</li>
-<li>Query - <code>&lt;md-progress-bar mode=&quot;query&quot;&gt;</code><ul>
-<li>Indicates the user must wait while something finishes when it is not yet possible to indicate how long it will take, but will be possible.  Once possible, the progress mode should be moved to buffer or determinate.</li>
-</ul>
-</li>
-</ol>
-<p>Example:</p>
-<pre><code class="lang-html">&lt;md-progress-bar mode=&quot;determinate&quot; value=&quot;myValue&quot;&gt;&lt;/md-progress-bar&gt;
-&lt;md-progress-bar mode=&quot;indeterminate&quot;&gt;&lt;/md-progress-bar&gt;
-&lt;md-progress-bar mode=&quot;buffer&quot; value=&quot;myValue&quot; bufferValue=&quot;myBufferValue&quot;&gt;&lt;/md-progress-bar&gt;
-&lt;md-progress-bar mode=&quot;query&quot;&gt;&lt;/md-progress-bar&gt;
-</code></pre>
-<h3 id="theming">Theming</h3>
-<p>All progress indicators can be themed to match your &quot;primary&quot; palette, your &quot;accent&quot; palette, or your &quot;warn&quot; palette using the appropriate class.</p>
-<p>Example:</p>
-<pre><code class="lang-html">&lt;md-progress-bar mode=&quot;indeterminate&quot; color=&quot;primary&quot;&gt;&lt;/md-progress-bar&gt;
-&lt;md-progress-bar mode=&quot;indeterminate&quot; color=&quot;accent&quot;&gt;&lt;/md-progress-bar&gt;
-&lt;md-progress-bar mode=&quot;indeterminate&quot; color=&quot;warn&quot;&gt;&lt;/md-progress-bar&gt;
-</code></pre>
-<h3 id="accessibility">Accessibility</h3>
-<ul>
-<li>ARIA attributes are applied to the indicator defining the valuemin, valuemax and valuenow attributes.</li>
-</ul>
-<h3 id="api-summary">API Summary</h3>
-<p>Properties:</p>
+<p><code>&lt;md-progress-bar&gt;</code> is a horizontal progress-bar for indicating progress and activity.</p>
+<div material-docs-example="progress-bar-overview"></div>
+<h3 id="progress-mode">Progress mode</h3>
+<p>The progress-bar supports four modes.</p>
 <table>
 <thead>
 <tr>
-<th>Name</th>
-<th>Type</th>
+<th>Mode</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>color</code></td>
-<td>`&quot;primary&quot;</td>
-<td>&quot;accent&quot;</td>
-<td>&quot;warn&quot;`</td>
-<td>The color palette of the progress indicator</td>
+<td>determinate</td>
+<td>Standard progress bar, fills from 0% to 100%</td>
 </tr>
 <tr>
-<td><code>mode</code></td>
-<td>`&quot;determinate&quot;</td>
-<td>&quot;indeterminate&quot;</td>
-<td>&quot;buffer&quot;</td>
-<td>&quot;query&quot;`</td>
-<td>The mode of the progress indicator</td>
+<td>indeterminate</td>
+<td>Indicates that something is happening without conveying a discrete progress</td>
 </tr>
 <tr>
-<td><code>value</code></td>
-<td>number</td>
-<td>The current progress percentage for determinate indicators</td>
+<td>buffer</td>
+<td>Dual-progress mode, typically showing both video download and playback progress</td>
 </tr>
 <tr>
-<td><code>bufferValue</code></td>
-<td>number</td>
-<td>The current progress percentage for buffer secondary indicators</td>
+<td>query</td>
+<td>Dual-stage mode, typically showing sending a request and downloading a response</td>
 </tr>
 </tbody>
 </table>
+<p>The default mode is &quot;determinate&quot;. In this mode, the progress is set via the <code>value</code> property, 
+which can be a whole number between 0 and 100.</p>
+<p>In &quot;buffer&quot; mode, <code>value</code> determines the progress of the primary bar while the <code>bufferValue</code> is 
+used to show the additional buffering progress.</p>
+<p>In &quot;query&quot; mode, the progress-bar renders as an inverted &quot;indeterminate&quot; bar. Once the response 
+progress is available, the <code>mode</code> should be changed to determinate to convey the progress.  </p>
+<p>In both &quot;indeterminate&quot; and &quot;query&quot; modes, the <code>value</code> property is ignored.</p>
+<h3 id="theming">Theming</h3>
+<p>The color of a progress-bar can be changed by using the <code>color</code> property. By default, progress-bars
+use the theme&#39;s primary color. This can be changed to <code>&#39;accent&#39;</code> or <code>&#39;warn&#39;</code>.  </p>

--- a/src/assets/documents/overview/progress-spinner.html
+++ b/src/assets/documents/overview/progress-spinner.html
@@ -1,67 +1,29 @@
-<h1 id="md-progress-spinner">md-progress-spinner</h1>
-<p><code>md-progress-spinner</code> is a component for indicating progress and activity, matching the spec of 
-<a href="https://www.google.com/design/spec/components/progress-activity.html">Material Design Progress &amp; Activity</a>.</p>
-<h3 id="progress-modes">Progress Modes</h3>
-<p>There are two modes:</p>
-<ol>
-<li>Determinate - <code>&lt;md-progress-spinner mode=&quot;determinate&quot;&gt;</code><ul>
-<li>Indicates how long an operation will take when the percentage complete is detectable. </li>
-</ul>
-</li>
-<li>Indeterminate - <code>&lt;md-progress-spinner mode=&quot;indeterminate&quot;&gt;</code> or <code>&lt;md-spinner&gt;</code><ul>
-<li>Indicates the user must wait while something finishes when it’s not necessary or possible to indicate how long it
-will take.</li>
-</ul>
-</li>
-</ol>
-<p>Example:</p>
-<pre><code class="lang-html">&lt;md-progress-spinner mode=&quot;determinate&quot; [value]=&quot;myValue&quot;&gt;&lt;/md-progress-spinner&gt;
-&lt;md-progress-spinner mode=&quot;indeterminate&quot;&gt;&lt;/md-progress-spinner&gt;
-&lt;md-spinner&gt;&lt;/md-spinner&gt;
-</code></pre>
-<h3 id="theming">Theming</h3>
-<p>All progress indicators can be themed to match your &quot;primary&quot; palette, your &quot;accent&quot; palette, or your &quot;warn&quot; palette using the appropriate class.</p>
-<p>Example:</p>
-<pre><code class="lang-html">&lt;md-progress-spinner mode=&quot;indeterminate&quot; color=&quot;primary&quot;&gt;&lt;/md-progress-spinner&gt;
-&lt;md-progress-spinner mode=&quot;indeterminate&quot; color=&quot;accent&quot;&gt;&lt;/md-progress-spinner&gt;
-&lt;md-progress-spinner mode=&quot;indeterminate&quot; color=&quot;warn&quot;&gt;&lt;/md-progress-spinner&gt;
-</code></pre>
-<h3 id="accessibility">Accessibility</h3>
-<ul>
-<li>ARIA attributes are applied to the indicator defining the valuemin, valuemax and valuenow attributes.</li>
-</ul>
-<h3 id="upcoming-work">Upcoming work</h3>
-<ul>
-<li>Adding ARIA attribute for progressbar &quot;for&quot;.</li>
-</ul>
-<h3 id="api-summary">API Summary</h3>
-<p>Properties:</p>
+<p><code>&lt;md-progress-spinner&gt;</code> and <code>&lt;md-spinner&gt;</code> are a circular indicators of progress and activity.</p>
+<div material-docs-example="progress-spinner-overview"></div>
+<h3 id="progress-mode">Progress mode</h3>
+<p>The progress-spinner supports two modes, &quot;determinate&quot; and &quot;indeterminate&quot;. 
+The <code>&lt;md-spinner&gt;</code> component is an alias for <code>&lt;md-progress-spinner mode=&quot;indeterminate&quot;&gt;</code>.</p>
 <table>
 <thead>
 <tr>
-<th>Name</th>
-<th>Type</th>
+<th>Mode</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>color</code></td>
-<td>`&quot;primary&quot;</td>
-<td>&quot;accent&quot;</td>
-<td>&quot;warn&quot;`</td>
-<td>The color palette of the progress indicator</td>
+<td>determinate</td>
+<td>Standard progress indicator, fills from 0% to 100%</td>
 </tr>
 <tr>
-<td><code>mode</code></td>
-<td>`&quot;determinate&quot;</td>
-<td>&quot;indeterminate&quot;`</td>
-<td>The mode of the progress indicator</td>
-</tr>
-<tr>
-<td><code>value</code></td>
-<td>number</td>
-<td>The current progress percentage for determinate indicators</td>
+<td>indeterminate</td>
+<td>Indicates that something is happening without conveying a discrete progress</td>
 </tr>
 </tbody>
 </table>
+<p>The default mode is &quot;determinate&quot;. In this mode, the progress is set via the <code>value</code> property, 
+which can be a whole number between 0 and 100.</p>
+<p>In &quot;indeterminate&quot; mode, the <code>value</code> property is ignored.</p>
+<h3 id="theming">Theming</h3>
+<p>The color of a progress-spinner can be changed by using the <code>color</code> property. By default, 
+progress-spinners use the theme&#39;s primary color. This can be changed to <code>&#39;accent&#39;</code> or <code>&#39;warn&#39;</code>.</p>

--- a/src/assets/documents/overview/radio.html
+++ b/src/assets/documents/overview/radio.html
@@ -1,102 +1,20 @@
-<h1 id="mdradio">MdRadio</h1>
-<p>Radio buttons allow the user to select one option from a set. Use radio buttons for exclusive selection if you think that the user needs to see all available options side-by-side.</p>
-<p><img src="https://material.angularjs.org/material2_assets/radio/radios.png" alt="Preview"></p>
-<h3 id="examples">Examples</h3>
-<p>A basic radio group would have the following markup.</p>
-<pre><code class="lang-html">&lt;md-radio-group&gt;
-  &lt;md-radio-button value=&quot;option_1&quot;&gt;1&lt;/md-radio-button&gt;
-  &lt;md-radio-button value=&quot;option_2&quot;&gt;2&lt;/md-radio-button&gt;
-&lt;/md-radio-group&gt;
-</code></pre>
-<p>A dynamic example for use inside a form showing support for <code>[(ngModel)]</code>:</p>
-<pre><code class="lang-html">&lt;md-radio-group [(ngModel)]=&quot;chosenOption&quot;&gt;
-  &lt;md-radio-button *ngFor=&quot;let o of options&quot; [value]=&quot;o.value&quot;&gt;
-    {{o.label}}
-  &lt;/md-radio-button&gt;
-&lt;/md-radio-group&gt;
-</code></pre>
-<h2 id="-md-radio-group-"><code>&lt;md-radio-group&gt;</code></h2>
-<h3 id="properties">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>selected</code></td>
-<td><code>MdRadioButton</code></td>
-<td>The currently selected button.</td>
-</tr>
-<tr>
-<td><code>value</code></td>
-<td><code>any</code></td>
-<td>The current value for this group.</td>
-</tr>
-<tr>
-<td><code>disabled</code></td>
-<td><code>boolean</code></td>
-<td>Whether the group is disabled.</td>
-</tr>
-</tbody>
-</table>
-<p>When selection is changed, an event is emitted from the <code>change</code> EventEmitter property.</p>
-<h3 id="notes">Notes</h3>
-<p>The <code>md-radio-group</code> component has no button initially selected.</p>
-<h2 id="-md-radio-button-"><code>&lt;md-radio-button&gt;</code></h2>
-<h3 id="properties">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name (attribute)</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>id</code></td>
-<td><code>string</code></td>
-<td>The unique ID of this radio button.</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td><code>string</code></td>
-<td>Group name, defaults to parent radio group if present.</td>
-</tr>
-<tr>
-<td><code>value</code></td>
-<td><code>any</code></td>
-<td>The value of this radio button.</td>
-</tr>
-<tr>
-<td><code>checked</code></td>
-<td><code>boolean</code></td>
-<td>Whether the radio is checked.</td>
-</tr>
-<tr>
-<td><code>disabled</code></td>
-<td><code>boolean</code></td>
-<td>Whether the radio is disabled.</td>
-</tr>
-<tr>
-<td><code>aria-label</code></td>
-<td><code>string</code></td>
-<td>Used to set the <code>aria-label</code> attribute of the underlying input element.</td>
-</tr>
-<tr>
-<td><code>aria-labelledby</code></td>
-<td><code>string</code></td>
-<td>Used to set the <code>aria-labelledby</code> attribute of the underlying input element.</td>
-</tr>
-</tbody>
-</table>
-<pre><code>                             If provided, this attribute takes precedence as the element&#39;s text alternative. |
-</code></pre><p>When checked, an event is emitted from the <code>change</code> EventEmitter property.</p>
-<h3 id="notes">Notes</h3>
-<ul>
-<li>The <code>md-radio-button</code> component by default uses the accent color from the theme palette.</li>
-</ul>
+<p><code>&lt;md-radio&gt;</code> provides the same functionality as a native <code>&lt;input type=&quot;radio&quot;&gt;</code> enhanced with 
+Material Design styling and animations.  </p>
+<div material-docs-example="radio-overview"></div>
+<p>All radio buttons with the same <code>name</code> comprise a set from which only one may be selected at a time.</p>
+<h3 id="radio-button-label">Radio-button label</h3>
+<p>The radio-button label is provided as the content to the <code>&lt;md-checkbox&gt;</code> element. The label can be 
+positioned before or after the radio-button by setting the <code>labelPosition</code> property to <code>&#39;before&#39;</code> 
+or <code>&#39;after&#39;</code>.</p>
+<p>If you don&#39;t want the label to appear next to the radio-button, you can use 
+<a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-label"><code>aria-label</code></a> or 
+<a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby"><code>aria-labelledby</code></a> to 
+specify an appropriate label.</p>
+<h3 id="radio-groups">Radio groups</h3>
+<p>Radio-buttons should typically be placed inside of an <code>&lt;md-radio-group&gt;</code> unless the DOM structure
+would make that impossible (e.g., radio buttons inside of table cells). The radio-group has a 
+<code>value</code> property that reflects the currently selected radio-button inside of the group.</p>
+<p>Individual radio-buttons inside of a radio-group will inherit the <code>name</code> of the group.</p>
+<h3 id="use-with-angular-forms-">Use with <code>@angular/forms</code></h3>
+<p><code>&lt;md-radio-group&gt;</code> is compatible with <code>@angular/forms</code> and supports both <code>FormsModule</code> 
+and <code>ReactiveFormsModule</code>.</p>

--- a/src/assets/documents/overview/select.html
+++ b/src/assets/documents/overview/select.html
@@ -1,2 +1,6 @@
-<h2 id="work-in-progress-">Work in progress!</h2>
-<p>The select is still a work in progress, so most features have not been implemented. Not ready for use!</p>
+<p><code>&lt;md-select&gt;</code> is a form control for selecting a value from a set of options, similar to the native
+<code>&lt;select&gt;</code> element.</p>
+<div material-docs-example="select-overview"></div>
+<h3 id="use-with-angular-forms-">Use with <code>@angular/forms</code></h3>
+<p><code>&lt;md-select&gt;</code> is compatible with <code>@angular/forms</code> and supports both <code>FormsModule</code> 
+and <code>ReactiveFormsModule</code>.</p>

--- a/src/assets/documents/overview/sidenav.html
+++ b/src/assets/documents/overview/sidenav.html
@@ -1,123 +1,56 @@
-<p><strong>NOTE: The <code>md-sidenav-layout</code> element is deprecated. <code>md-sidenav-container</code>
-should be used instead.</strong></p>
-<h1 id="mdsidenav">MdSidenav</h1>
-<p>MdSidenav is the side navigation component for Material 2. It is composed of two components: <code>&lt;md-sidenav-container&gt;</code> and <code>&lt;md-sidenav&gt;</code>.</p>
-<h2 id="screenshots">Screenshots</h2>
-<p><img src="https://material.angularjs.org/material2_assets/sidenav-example.png"></p>
-<h2 id="-md-sidenav-container-"><code>&lt;md-sidenav-container&gt;</code></h2>
-<p>The parent component. Contains the code necessary to coordinate one or two sidenav and the backdrop.</p>
-<h2 id="-md-sidenav-"><code>&lt;md-sidenav&gt;</code></h2>
-<p>The sidenav panel.</p>
-<h3 id="bound-properties">Bound Properties</h3>
+<p><code>&lt;md-sidenav&gt;</code> is a panel that can be placed next to or above some primary content. A sidenav is
+typically used for navigation, but can contain any content.</p>
+<div material-docs-example="sidenav-overview"></div>
+<p>The sidenav and its associated content live inside of an <code>&lt;md-sidenav-container&gt;</code>:</p>
+<pre><code class="lang-html">&lt;md-sidenav-container&gt;
+  &lt;md-sidenav&gt;
+    &lt;!-- sidenav content --&gt;
+  &lt;/md-sidenav&gt;
+
+  &lt;!-- primary content --&gt;
+&lt;/md-sidenav-container&gt;
+</code></pre>
+<p>A sidenav container may contain one or two <code>&lt;md-sidenav&gt;</code> elements. When there are two 
+<code>&lt;md-sidenav&gt;</code> elements, each must be placed on a different side of the container.
+See the section on positioning below.</p>
+<h3 id="sidenav-mode">Sidenav mode</h3>
+<p>The sidenav can render in one of three different ways based on the <code>mode</code> property.</p>
 <table>
 <thead>
 <tr>
-<th>Name</th>
-<th>Type</th>
+<th>Mode</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>align</code></td>
-<td>`&quot;start&quot;</td>
-<td>&quot;end&quot;`</td>
-<td>The alignment of this sidenav. In LTR direction, <code>&quot;start&quot;</code> will be shown on the left, <code>&quot;end&quot;</code> on the right. In RTL, it is reversed. <code>&quot;start&quot;</code> is used by default. If there is more than 1 sidenav on either side the container will be considered invalid and none of the sidenavs will be visible or toggleable until the container is valid again.</td>
+<td>over</td>
+<td>Sidenav floats <em>over</em> the primary content, which is covered by a backdrop</td>
 </tr>
 <tr>
-<td><code>mode</code></td>
-<td>`&quot;over&quot;</td>
-<td>&quot;push&quot;</td>
-<td>&quot;side&quot;`</td>
-<td>The mode or styling of the sidenav, default being <code>&quot;over&quot;</code>. With <code>&quot;over&quot;</code> the sidenav will appear above the content, and a backdrop will be shown. With <code>&quot;push&quot;</code> the sidenav will push the content of the <code>&lt;md-sidenav-container&gt;</code> to the side, and show a backdrop over it. <code>&quot;side&quot;</code> will resize the content and keep the sidenav opened. Clicking the backdrop will close sidenavs that do not have <code>mode=&quot;side&quot;</code>.</td>
+<td>push</td>
+<td>Sidenav <em>pushes</em> the primary content out of its way, also covering it with a backdrop</td>
 </tr>
 <tr>
-<td><code>opened</code></td>
-<td><code>boolean</code></td>
-<td>Whether or not the sidenav is opened. Use this binding to open/close the sidenav.</td>
+<td>side</td>
+<td>Sidenav appears <em>side-by-side</em> with the primary content</td>
 </tr>
 </tbody>
 </table>
-<h3 id="events">Events</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>open-start</code></td>
-<td>Emitted when the sidenav is starting opening. This should only be used to coordinate animations.</td>
-</tr>
-<tr>
-<td><code>close-start</code></td>
-<td>Emitted when the sidenav is starting closing. This should only be used to coordinate animations.</td>
-</tr>
-<tr>
-<td><code>open</code></td>
-<td>Emitted when the sidenav is done opening. Use this for, e.g., setting focus on controls or updating state.</td>
-</tr>
-<tr>
-<td><code>close</code></td>
-<td>Emitted when the sidenav is done closing.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="methods">Methods</h3>
-<table>
-<thead>
-<tr>
-<th>Signature</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>open(): Promise&lt;void&gt;</code></td>
-<td>Open the sidenav. Equivalent to <code>opened = true</code>. Returns a promise that will resolve when the animation completes, or be rejected if the animation was cancelled.</td>
-</tr>
-<tr>
-<td><code>close(): Promise&lt;void&gt;</code></td>
-<td>Close the sidenav. Equivalent to <code>opened = false</code>. Returns a promise that will resolve when the animation completes, or be rejected if the animation was cancelled.</td>
-</tr>
-<tr>
-<td><code>toggle(): Promise&lt;void&gt;</code></td>
-<td>Toggle the sidenav. This is equivalent to <code>opened = !opened</code>. Returns a promise that will resolve when the animation completes, or be rejected if the animation was cancelled.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="notes">Notes</h3>
-<p>The <code>&lt;md-sidenav&gt;</code> will resize based on its content. You can also set its width in CSS, like so:</p>
+<h3 id="positioning-the-sidenav">Positioning the sidenav</h3>
+<p>The <code>align</code> property determines whether the sidenav appears at the <code>&quot;start&quot;</code> or <code>&quot;end&quot;</code> of the
+container. This is affected by the current text direction (&quot;ltr&quot; or &quot;rtl&quot;). By default, the sidenav
+appears at the start of the container.</p>
+<h3 id="sizing-the-sidenav">Sizing the sidenav</h3>
+<p>The <code>&lt;md-sidenav&gt;</code> will, by default, fit the size of its content. The width can be explicitly set
+via CSS:</p>
 <pre><code class="lang-css">md-sidenav {
   width: 200px;
 }
 </code></pre>
 <p>Try to avoid percent based width as <code>resize</code> events are not (yet) supported.</p>
-<h2 id="examples">Examples</h2>
-<p>Here&#39;s a simple example of using the sidenav:</p>
-<pre><code class="lang-html">&lt;app&gt;
-  &lt;md-sidenav-container&gt;
-    &lt;md-sidenav #start (open)=&quot;closeStartButton.focus()&quot;&gt;
-      Start Sidenav.
-      &lt;br&gt;
-      &lt;button md-button #closeStartButton (click)=&quot;start.close()&quot;&gt;Close&lt;/button&gt;
-    &lt;/md-sidenav&gt;
-    &lt;md-sidenav #end align=&quot;end&quot;&gt;
-      End Sidenav.
-      &lt;button md-button (click)=&quot;end.close()&quot;&gt;Close&lt;/button&gt;
-    &lt;/md-sidenav&gt;
-
-    My regular content. This will be moved into the proper DOM at runtime.
-    &lt;button md-button (click)=&quot;start.open()&quot;&gt;Open start sidenav&lt;/button&gt;
-    &lt;button md-button (click)=&quot;end.open()&quot;&gt;Open end sidenav&lt;/button&gt;
-
-  &lt;/md-sidenav-container&gt;
-&lt;/app&gt;
-</code></pre>
 <p>For a fullscreen sidenav, the recommended approach is set up the DOM such that the
-<code>md-sidenav-container</code> can naturally take up the full space:</p>
+<code>&lt;md-sidenav-container&gt;</code> can naturally take up the full space:</p>
 <pre><code class="lang-html">&lt;app&gt;
   &lt;md-sidenav-container&gt;
     &lt;md-sidenav mode=&quot;side&quot; opened=&quot;true&quot;&gt;Drawer content&lt;/md-sidenav&gt;
@@ -131,64 +64,6 @@ should be used instead.</strong></p>
   height: 100%;
 }
 </code></pre>
+<h3 id="fabs-inside-sidenav">FABs inside sidenav</h3>
 <p>For a sidenav with a FAB (or other floating element), the recommended approach is to place the FAB
 outside of the scrollable region and absolutely position it.</p>
-<pre><code class="lang-html">&lt;app&gt;
-  &lt;md-sidenav-container class=&quot;my-container&quot;&gt;
-    &lt;md-sidenav mode=&quot;side&quot; opened=&quot;true&quot;&gt;
-      &lt;button md-mini-fab class=&quot;my-fab&quot;&gt;
-        &lt;md-icon&gt;add&lt;/md-icon&gt;
-      &lt;/button&gt;
-      &lt;div class=&quot;my-scrolling-content&quot;&gt;
-        Lorem ipsum dolor sit amet, pede a libero aenean phasellus, lectus metus sint ut risus,
-        fusce vel in pellentesque. Nisl rutrum etiam morbi consectetuer tempor magna, aenean nullam
-        nunc id, neque vivamus interdum sociis nulla scelerisque sem, dolor id wisi turpis magna
-        aliquam magna. Risus accumsan hac eget etiam donec sed, senectus erat mattis quam, tempor
-        vel urna occaecat cras, metus urna augue nec at. Et morbi amet dui praesent, nec eu at,
-        ligula ipsum dui sollicitudin, quis nisl massa viverra ligula, mauris fermentum orci arcu
-        enim fringilla. Arcu erat nulla in aenean lacinia ullamcorper, urna ante nam et sagittis,
-        tristique vehicula nibh ipsum vivamus, proin proin. Porta commodo nibh quis libero amet.
-        Taciti dui, sapien consectetuer.
-      &lt;/div&gt;
-    &lt;/md-sidenav&gt;
-    &lt;button md-mini-fab class=&quot;my-fab&quot;&gt;
-      &lt;md-icon&gt;add&lt;/md-icon&gt;
-    &lt;/button&gt;
-    &lt;div class=&quot;my-scrolling-content&quot;&gt;
-      Lorem ipsum dolor sit amet, pede a libero aenean phasellus, lectus metus sint ut risus, fusce
-      vel in pellentesque. Nisl rutrum etiam morbi consectetuer tempor magna, aenean nullam nunc id,
-      neque vivamus interdum sociis nulla scelerisque sem, dolor id wisi turpis magna aliquam magna.
-      Risus accumsan hac eget etiam donec sed, senectus erat mattis quam, tempor vel urna occaecat
-      cras, metus urna augue nec at. Et morbi amet dui praesent, nec eu at, ligula ipsum dui
-      sollicitudin, quis nisl massa viverra ligula, mauris fermentum orci arcu enim fringilla. Arcu
-      erat nulla in aenean lacinia ullamcorper, urna ante nam et sagittis, tristique vehicula nibh
-      ipsum vivamus, proin proin. Porta commodo nibh quis libero amet. Taciti dui, sapien
-      consectetuer.
-    &lt;/div&gt;
-  &lt;/md-sidenav-container&gt;
-&lt;/app&gt;
-</code></pre>
-<pre><code class="lang-css">.my-container {
-  width: 500px;
-  height: 300px;
-}
-
-.my-container md-sidenav {
-  max-width: 200px;
-}
-
-.my-container .md-sidenav-content,
-.my-container md-sidenav {
-  display: flex;
-}
-
-.my-scrolling-content {
-  overflow: auto;
-}
-
-button.my-fab {
-  position: absolute;
-  right: 20px;
-  bottom: 10px;
-}
-</code></pre>

--- a/src/assets/documents/overview/slide-toggle.html
+++ b/src/assets/documents/overview/slide-toggle.html
@@ -1,85 +1,17 @@
-<h1 id="mdslidetoggle">MdSlideToggle</h1>
-<p><code>MdSlideToggle</code> is a two-state control, which can be also called <code>switch</code></p>
-<h3 id="screenshots">Screenshots</h3>
-<p><img src="https://material.angularjs.org/material2_assets/slide-toggle/toggles.png" alt="image"></p>
-<h2 id="-md-slide-toggle-"><code>&lt;md-slide-toggle&gt;</code></h2>
-<h3 id="bound-properties">Bound Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>disabled</code></td>
-<td>boolean</td>
-<td>Disables the <code>slide-toggle</code></td>
-</tr>
-<tr>
-<td><code>color</code></td>
-<td>`&quot;primary&quot;</td>
-<td>&quot;accent&quot;</td>
-<td>&quot;warn&quot;`</td>
-<td>The color palette of the <code>slide-toggle</code></td>
-</tr>
-<tr>
-<td><code>checked</code></td>
-<td>boolean</td>
-<td>Sets the value of the <code>slide-toggle</code></td>
-</tr>
-</tbody>
-</table>
-<h3 id="events">Events</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>change</code></td>
-<td>boolean</td>
-<td>Event will be emitted on every value change.<br/>It emits the new <code>checked</code> value.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="examples">Examples</h3>
-<p>A basic slide-toggle would have the following markup.</p>
-<pre><code class="lang-html">&lt;md-slide-toggle [(ngModel)]=&quot;slideToggleModel&quot;&gt;
-  Default Slide Toggle
-&lt;/md-slide-toggle&gt;
-</code></pre>
-<p>Slide toggle can be also disabled.</p>
-<pre><code class="lang-html">&lt;md-slide-toggle disabled&gt;
-  Disabled Slide Toggle
-&lt;/md-slide-toggle&gt;
-</code></pre>
-<p>The <code>slide-toggle</code> can be also set to checked without a <code>ngModel</code></p>
-<pre><code class="lang-html">&lt;md-slide-toggle [checked]=&quot;isChecked&quot;&gt;
-  Input Binding
-&lt;/md-slide-toggle&gt;
-</code></pre>
-<p>You may also want to listen on changes of the <code>slide-toggle</code><br/>
-The <code>slide-toggle</code> always emits the new value to the event binding <code>(change)</code></p>
-<pre><code class="lang-html">&lt;md-slide-toggle (change)=&quot;printValue($event)&quot;&gt;
-  Prints Value on Change
-&lt;/md-slide-toggle&gt;
-</code></pre>
-<h2 id="theming">Theming</h2>
-<p>A slide-toggle is default using the <code>accent</code> palette for its styling.</p>
-<p>Modifying the color on a <code>slide-toggle</code> can be easily done, by using the following markup.</p>
-<pre><code class="lang-html">&lt;md-slide-toggle color=&quot;primary&quot;&gt;
-  Primary Slide Toggle
-&lt;/md-slide-toggle&gt;
-</code></pre>
-<p>The color can be also set dynamically by using a property binding.</p>
-<pre><code class="lang-html">&lt;md-slide-toggle [color]=&quot;myColor&quot;&gt;
-  Dynamic Color
-&lt;/md-slide-toggle&gt;
-</code></pre>
+<p><code>&lt;md-slide-toggle&gt;</code> is an on/off control that can be toggled via clicking or dragging. </p>
+<div material-docs-example="slide-toggle-overview"></div>
+<p>The slide-toggle behaves similarly to a checkbox, though it does not support an <code>indeterminate</code> 
+state like <code>&lt;md-checkbox&gt;</code>.</p>
+<p><em>Note: the sliding behavior for this component requires that HammerJS is loaded on the page.</em></p>
+<h3 id="slide-toggle-label">Slide-toggle label</h3>
+<p>The slide-toggle label is provided as the content to the <code>&lt;md-slide-toggle&gt;</code> element. </p>
+<p>If you don&#39;t want the label to appear next to the slide-toggle, you can use 
+<a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-label"><code>aria-label</code></a> or 
+<a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby"><code>aria-labelledby</code></a> to 
+specify an appropriate label.</p>
+<h3 id="use-with-angular-forms-">Use with <code>@angular/forms</code></h3>
+<p><code>&lt;md-slide-toggle&gt;</code> is compatible with <code>@angular/forms</code> and supports both <code>FormsModule</code> 
+and <code>ReactiveFormsModule</code>.</p>
+<h3 id="theming">Theming</h3>
+<p>The color of a <code>&lt;md-slide-toggle&gt;</code> can be changed by using the <code>color</code> property. By default, 
+slide-toggles use the theme&#39;s accent color. This can be changed to <code>&#39;primary&#39;</code> or <code>&#39;warn&#39;</code>.  </p>

--- a/src/assets/documents/overview/slider.html
+++ b/src/assets/documents/overview/slider.html
@@ -1,18 +1,14 @@
-<h1 id="md-slider">md-slider</h1>
-<p><code>md-slider</code> is a component that allows users to select from a range of values by moving the slider
-thumb. It is similar in behavior to the native <code>&lt;input type=&quot;range&quot;&gt;</code> element. You can read more
-about the slider in the <a href="https://material.google.com/components/sliders.html">Material Design spec</a>.</p>
-<p>Simple example:</p>
-<pre><code class="lang-html">&lt;md-slider&gt;&lt;/md-slider&gt;
-</code></pre>
-<h2 id="usage">Usage</h2>
-<h3 id="changing-the-min-max-step-and-initial-value">Changing the min, max, step, and initial value</h3>
+<p><code>&lt;md-slider&gt;</code> allows for the selection of a value from a range via mouse, touch, or keyboard, 
+similar to <code>&lt;input type=&quot;range&quot;&gt;</code>.</p>
+<div material-docs-example="slider-overview"></div>
+<p><em>Note: the sliding behavior for this component requires that HammerJS is loaded on the page.</em></p>
+<h3 id="selecting-a-value">Selecting a value</h3>
 <p>By default the minimum value of the slider is <code>0</code>, the maximum value is <code>100</code>, and the thumb moves
 in increments of <code>1</code>. These values can be changed by setting the <code>min</code>, <code>max</code>, and <code>step</code> attributes
 respectively. The initial value is set to the minimum value unless otherwise specified.</p>
 <pre><code class="lang-html">&lt;md-slider min=&quot;1&quot; max=&quot;5&quot; step=&quot;0.5&quot; value=&quot;1.5&quot;&gt;&lt;/md-slider&gt;
 </code></pre>
-<h3 id="setting-the-orientation">Setting the orientation</h3>
+<h3 id="orientation">Orientation</h3>
 <p>By default sliders are horizontal with the minimum value on the left and the maximum value on the
 right. The <code>vertical</code> attribute can be added to a slider to make it vertical with the minimum value
 on bottom and the maximum value on top.</p>
@@ -24,16 +20,16 @@ on the left, while an inverted vertical slider will have the minimum value on to
 value on bottom.</p>
 <pre><code class="lang-html">&lt;md-slider invert&gt;&lt;/md-slider&gt;
 </code></pre>
-<h3 id="adding-a-thumb-label">Adding a thumb label</h3>
-<p>By default the exact selected value of a slider is not visible to the user. However, this value can
+<h3 id="thumb-label">Thumb label</h3>
+<p>By default, the exact selected value of a slider is not visible to the user. However, this value can
 be added to the thumb by adding the <code>thumbLabel</code> attribute.</p>
-<p>The <a href="https://material.google.com/components/sliders.html">material design spec</a> recommends using the
+<p>The <a href="https://material.google.com/components/sliders.html">Material Design spec</a> recommends using the
 <code>thumbLabel</code> attribute (along with <code>tickInterval=&quot;1&quot;</code>) only for sliders that are used to display a
 discrete value (such as a 1-5 rating).</p>
 <pre><code class="lang-html">&lt;md-slider thumbLabel tickInterval=&quot;1&quot;&gt;&lt;/md-slider&gt;
 </code></pre>
-<h3 id="adding-ticks">Adding ticks</h3>
-<p>By default a sliders do not show tick marks along the thumb track. They can be enabled using the
+<h3 id="tick-marks">Tick marks</h3>
+<p>By default, sliders do not show tick marks along the thumb track. This can be enabled using the
 <code>tickInterval</code> attribute. The value of <code>tickInterval</code> should be a number representing the number
 of steps between between ticks. For example a <code>tickInterval</code> of <code>3</code> with a <code>step</code> of <code>4</code> will draw
 tick marks at every <code>3</code> steps, which is the same as every <code>12</code> values.</p>
@@ -46,22 +42,10 @@ such that there is at least <code>30px</code> of space between ticks.</p>
 <p>The slider will always show a tick at the beginning and end of the track. If the remaining space
 doesn&#39;t add up perfectly the last interval will be shortened or lengthened so that the tick can be
 shown at the end of the track.</p>
-<p>The <a href="https://material.google.com/components/sliders.html">material design spec</a> recommends using the
+<p>The <a href="https://material.google.com/components/sliders.html">Material Design spec</a> recommends using the
 <code>tickInterval</code> attribute (set to <code>1</code> along with the <code>thumbLabel</code> attribute) only for sliders that
 are used to display a discrete value (such as a 1-5 rating).</p>
-<h3 id="disabling-the-slider">Disabling the slider</h3>
-<p>The <code>disabled</code> attribute can be used to disable the slider, preventing the user from changing the
-value.</p>
-<pre><code class="lang-html">&lt;md-slider disabled value=&quot;5&quot;&gt;&lt;/md-slider&gt;
-</code></pre>
-<h3 id="value-binding">Value binding</h3>
-<p><code>md-slider</code> supports both 1-way binding and 2-way binding via <code>ngModel</code>. It also emits a <code>change</code>
-event when the value changes due to user interaction.</p>
-<pre><code class="lang-html">&lt;md-slider [value]=&quot;myValue&quot; (change)=&quot;onChange()&quot;&gt;&lt;/md-slider&gt;
-</code></pre>
-<pre><code class="lang-html">&lt;md-slider [(ngModel)]=&quot;myValue&quot;&gt;&lt;/md-slider&gt;
-</code></pre>
-<h2 id="accessibility">Accessibility</h2>
+<h3 id="keyboard-interaction">Keyboard interaction</h3>
 <p>The slider has the following keyboard bindings:</p>
 <table>
 <thead>
@@ -73,7 +57,7 @@ event when the value changes due to user interaction.</p>
 <tbody>
 <tr>
 <td>Right arrow</td>
-<td>Increment the slider value by one step. (Decrement in right-to-left-languages).</td>
+<td>Increment the slider value by one step (decrements in RTL).</td>
 </tr>
 <tr>
 <td>Up arrow</td>
@@ -81,7 +65,7 @@ event when the value changes due to user interaction.</p>
 </tr>
 <tr>
 <td>Left arrow</td>
-<td>Decrement the slider value by one step. (Increment in right-to-left-languages).</td>
+<td>Decrement the slider value by one step (decrements in RTL).</td>
 </tr>
 <tr>
 <td>Down arrow</td>
@@ -105,81 +89,3 @@ event when the value changes due to user interaction.</p>
 </tr>
 </tbody>
 </table>
-<h2 id="internationalization">Internationalization</h2>
-<p>In right-to-left languages the horizontal slider has the minimum value on the right and the maximum
-value on the left by default. The meaning of the left and right arrow keys is also swapped in
-right-to-left languages.</p>
-<h2 id="api-summary">API Summary</h2>
-<h3 id="inputs">Inputs</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>min</code></td>
-<td>number</td>
-<td>Optional, the minimum number for the slider. Default = <code>0</code>.</td>
-</tr>
-<tr>
-<td><code>max</code></td>
-<td>number</td>
-<td>Optional, the maximum number for the slider. Default = <code>100</code>.</td>
-</tr>
-<tr>
-<td><code>step</code></td>
-<td>number</td>
-<td>Optional, declares where the thumb will snap to. Default = <code>1</code>.</td>
-</tr>
-<tr>
-<td><code>value</code></td>
-<td>number</td>
-<td>Optional, the value to start the slider at.</td>
-</tr>
-<tr>
-<td><code>tickInterval</code></td>
-<td><code>&quot;auto&quot;</code> \</td>
-<td>number</td>
-<td>Optional, how many steps between tick marks.</td>
-</tr>
-<tr>
-<td><code>invert</code></td>
-<td>boolean</td>
-<td>Optional, whether to invert the axis the thumb moves along.</td>
-</tr>
-<tr>
-<td><code>vertical</code></td>
-<td>boolean</td>
-<td>Optional, whether the slider should be oriented vertically.</td>
-</tr>
-<tr>
-<td><code>disabled</code></td>
-<td>boolean</td>
-<td>Optional, whether or not the slider is disabled. Default = <code>false</code>.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="outputs">Outputs</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>change</code></td>
-<td>Emitted when the value changes due to user interaction.</td>
-</tr>
-</tbody>
-</table>
-<h2 id="future-work-open-questions">Future work &amp; open questions</h2>
-<ul>
-<li>Update focused, disabled, and <code>value=min</code> states to match spec.</li>
-<li>Should there be an option to not force the end tick to be shown?</li>
-</ul>

--- a/src/assets/documents/overview/snack-bar.html
+++ b/src/assets/documents/overview/snack-bar.html
@@ -1,64 +1,37 @@
-<h1 id="mdsnackbar">MdSnackBar</h1>
-<p><code>MdSnackBar</code> is a service, which opens snack bar notifications in the view.</p>
-<h3 id="methods">Methods</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>open(message: string, actionLabel: string, config: MdSnackBarConfig): MdSnackBarRef&lt;SimpleSnackBar&gt;</code></td>
-<td>Creates and opens a simple snack bar notification matching material spec.</td>
-</tr>
-<tr>
-<td><code>openFromComponent(component: ComponentType&lt;T&gt;, config: MdSnackBarConfig): MdSnackBarRef&lt;T&gt;</code></td>
-<td>Creates and opens a snack bar notification with a custom component as content.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="config">Config</h3>
-<table>
-<thead>
-<tr>
-<th>Key</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>viewContainerRef: ViewContainerRef</code></td>
-<td>The view container ref to attach the snack bar to.</td>
-</tr>
-<tr>
-<td><code>role: AriaLivePoliteness = &#39;assertive&#39;</code></td>
-<td>The politeness level to announce the snack bar with.</td>
-</tr>
-<tr>
-<td><code>announcementMessage: string</code></td>
-<td>The message to announce with the snack bar.</td>
-</tr>
-<tr>
-<td><code>duration: number</code></td>
-<td>The length of time in milliseconds to wait before autodismissing the snack bar.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="example">Example</h3>
-<p>The service can be injected in a component.</p>
-<pre><code class="lang-ts">@Component({
-  selector: &#39;my-component&#39;,
-  providers: [MdSnackBar]
-})
-export class MyComponent {
+<p><code>MdSnackBar</code> is a service for displaying snack-bar notifications.</p>
+<div material-docs-example="snackbar-overview"></div>
+<h3 id="opening-a-snack-bar">Opening a snack-bar</h3>
+<p>A snack-bar can contain either a string message or a given component.</p>
+<pre><code class="lang-ts">// Simple message.
+let snackBarRef = snackBar.open(&#39;Message archived&#39;);
 
- constructor(snackBar: MdSnackBar) {}
+// Simple message with an action.
+let snackBarRef = snackBar.open(&#39;Message archived&#39;, &#39;Undo&#39;);
 
- failedAttempt() {
-   this.snackBar.open(&#39;It didn\&#39;t quite work!&#39;, &#39;Try Again&#39;);
- }
+// Load the given component into the snack-bar.
+let snackBarRef = snackbar.openFromComponent(MessageArchivedComponent);
+</code></pre>
+<p>In either case, an <code>MdSnackBarRef</code> is returned. This can be used to dismiss the snack-bar or to 
+recieve notification of when the snack-bar is dismissed. For simple messages with an action, the 
+<code>MdSnackBarRef</code> exposes an observable for when the action is triggered.</p>
+<pre><code class="lang-ts">snackBarRef.afterDismissed().subscribe(() =&gt; {
+  console.log(&#39;The snack-bar was dismissed&#39;);
+});
 
-}
+
+snackBarRef.onAction().subscribe(() =&gt; {
+  console.log(&#39;The snack-bar action was triggered!&#39;);
+});
+
+snackBarRef.dismiss();
+</code></pre>
+<h3 id="dismissal">Dismissal</h3>
+<p>A snack-bar can be dismissed manually by calling the <code>dismiss</code> method on the <code>MdSnackBarRef</code> 
+returned from the call to <code>open</code>.</p>
+<p>Only one snack-bar can ever be opened at one time. If a new snackbar is opened while a previous
+message is still showing, the older message will be automatically dismissed.</p>
+<p>A snack-bar can also be given a duration via the optional configuration object:</p>
+<pre><code class="lang-ts">snackbar.open(&#39;Message archived&#39;, &#39;Undo&#39;, {
+  duration: 3000
+});
 </code></pre>

--- a/src/assets/documents/overview/tabs.html
+++ b/src/assets/documents/overview/tabs.html
@@ -1,47 +1,16 @@
-<h1 id="mdtabgroup">MdTabGroup</h1>
-<p>Tab groups allow the user to organize their content by labels such that only one tab is visible at any given time.</p>
-<h2 id="-md-tab-group-"><code>&lt;md-tab-group&gt;</code></h2>
-<h3 id="properties">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>selectedIndex</code></td>
-<td><code>number</code></td>
-<td>The index of the currently active tab.</td>
-</tr>
-</tbody>
-</table>
+<p>Angular Material tabs organize content into separate views where only one view can be
+visible at a time. Each tab&#39;s label is shown in the tab header and the active
+tab&#39;s label is designated with the animated ink bar. When the list of tab labels exceeds the width
+of the header, pagination controls appear to let the user scroll left and right across the labels.</p>
+<p>The active tab may be set using the <code>selectedIndex</code> input or when the user selects one of the
+tab labels in the header.</p>
+<div material-docs-example="tab-overview"></div>
 <h3 id="events">Events</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>focusChange</code></td>
-<td><code>Event</code></td>
-<td>Fired when focus changes from one label to another</td>
-</tr>
-<tr>
-<td><code>selectChange</code></td>
-<td><code>Event</code></td>
-<td>Fired when the selected tab changes</td>
-</tr>
-</tbody>
-</table>
-<h3 id="basic-use">Basic use</h3>
-<p>A basic tab group would have the following markup.</p>
+<p>The <code>selectChange</code> output event is emitted when the active tab changes.  </p>
+<p>The <code>focusChange</code> output event is emitted when the user puts focus on any of the tab labels in
+the header, usually through keyboard navigation. </p>
+<h3 id="labels">Labels</h3>
+<p>If a tab&#39;s label is only text then the simple tab-group API can be used.</p>
 <pre><code class="lang-html">&lt;md-tab-group&gt;
   &lt;md-tab label=&quot;One&quot;&gt;
     &lt;h1&gt;Some tab content&lt;/h1&gt;
@@ -53,15 +22,7 @@
   &lt;/md-tab&gt;
 &lt;/md-tab-group&gt;
 </code></pre>
-<p>You can specifiy the active tab by using the <code>selectedIndex</code> property.</p>
-<pre><code class="lang-html">&lt;md-tab-group [selectedIndex]=&quot;1&quot;&gt;
-  ...
-&lt;/md-tab-group&gt;
-</code></pre>
-<p><strong>Note</strong>: The index always starts counting from <code>zero</code>.</p>
-<h3 id="tabs-with-label-templates">Tabs with label templates</h3>
-<p>If you want to use an arbitrary template for your tab, you can use the <code>md-tab-label</code> directive to
-provide the label template:</p>
+<p>For more complex labels, add a template with the <code>md-tab-label</code> directive inside the <code>md-tab</code>.</p>
 <pre><code class="lang-html">&lt;md-tab-group&gt;
   &lt;md-tab&gt;
     &lt;template md-tab-label&gt;
@@ -79,3 +40,25 @@ provide the label template:</p>
   &lt;/md-tab&gt;
 &lt;/md-tab-group&gt;
 </code></pre>
+<h3 id="dynamic-height">Dynamic Height</h3>
+<p>By default, the tab group will not change its height to the height of the currently active tab. To
+change this, set the <code>dynamicHeight</code> input to true. The tab body will animate its height according
+ to the height of the active tab.</p>
+<h3 id="tabs-and-navigation">Tabs and navigation</h3>
+<p>While <code>&lt;md-tab-group&gt;</code> is used to switch between views within a single route, <code>&lt;nav md-tab-nav-bar&gt;</code>
+provides a tab-like UI for navigating between routes.</p>
+<pre><code class="lang-html">&lt;nav md-tab-nav-bar&gt;
+  &lt;a md-tab-link
+     *ngFor=&quot;let link of navLinks&quot;
+     [routerLink]=&quot;link&quot;
+     routerLinkActive #rla=&quot;routerLinkActive&quot;
+     [active]=&quot;rla.isActive&quot;&gt;
+    {{tabLink.label}}
+  &lt;/a&gt;
+&lt;/nav&gt;
+
+&lt;router-outlet&gt;&lt;/router-outlet&gt;
+</code></pre>
+<p>The tab-nav-bar is not tied to any particular router; it works with normal <code>&lt;a&gt;</code> elements and uses
+the <code>active</code> property to determine which tab is currently active. The corresponding 
+<code>&lt;router-outlet&gt;</code> can be placed anywhere in the view. </p>

--- a/src/assets/documents/overview/toolbar.html
+++ b/src/assets/documents/overview/toolbar.html
@@ -1,38 +1,10 @@
-<h1 id="mdtoolbar">MdToolbar</h1>
-<p><code>MdToolbar</code> is a vertical aligned bar, which can hold the application title or actions.</p>
-<h3 id="screenshots">Screenshots</h3>
-<p><img src="https://cloud.githubusercontent.com/assets/4987015/13727769/6d952c78-e900-11e5-890a-ccfd46996812.png" alt="Preview"></p>
-<h2 id="-md-toolbar-"><code>&lt;md-toolbar&gt;</code></h2>
-<h3 id="bound-properties">Bound Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>color</code></td>
-<td>`&quot;primary&quot;</td>
-<td>&quot;accent&quot;</td>
-<td>&quot;warn&quot;`</td>
-<td>The color palette for the toolbar</td>
-</tr>
-</tbody>
-</table>
-<h3 id="notes">Notes</h3>
-<p>The <code>md-toolbar</code> component will use by default the background palette.</p>
-<h3 id="examples">Examples</h3>
-<p>A basic toolbar would have the following markup.</p>
-<pre><code class="lang-html">&lt;md-toolbar [color]=&quot;myColor&quot;&gt;
-  &lt;span&gt;My Application Title&lt;/span&gt;
-&lt;/md-toolbar&gt;
-</code></pre>
-<p>Toolbars can also have multiple rows.<br/>
-Multiple rows inside of a <code>md-toolbar</code> can be added by appending as many as needed <code>&lt;md-toolbar-row&gt;</code> elements.</p>
-<pre><code class="lang-html">&lt;md-toolbar [color]=&quot;myColor&quot;&gt;
+<p><code>&lt;md-toolbar&gt;</code> is a container for headers, titles, or actions.</p>
+<div material-docs-example="toolbar-overview"></div>
+<h3 id="multiple-rows">Multiple rows</h3>
+<p>Toolbars can have multiple rows using <code>&lt;md-toolbar-row&gt;</code> elements. Any content outside of an 
+<code>&lt;md-toolbar-row&gt;</code> element are automatically placed inside of one at the begining of the toolbar.
+Each toolbar row is a <code>display: flex</code> container.</p>
+<pre><code class="lang-html">&lt;md-toolbar&gt;
   &lt;span&gt;First Row&lt;/span&gt;
 
   &lt;md-toolbar-row&gt;
@@ -44,10 +16,11 @@ Multiple rows inside of a <code>md-toolbar</code> can be added by appending as m
   &lt;/md-toolbar-row&gt;
 &lt;/md-toolbar&gt;
 </code></pre>
-<h3 id="alignment">Alignment</h3>
-<p>The alignment inside of a toolbar row can be easily done by using the flexbox layout.<br/>
-For example, the following markup aligns the items on the <code>right</code>.</p>
-<p>Custom HTML</p>
+<h3 id="positioning-toolbar-content">Positioning toolbar content</h3>
+<p>The toolbar does not perform any positioning of its content. This gives the user full power to 
+position the content as it suits their application.</p>
+<p>A common pattern is to position a title on the left with some actions on the right. This can be
+easily accomplished with <code>display: flex</code>:</p>
 <pre><code class="lang-html">&lt;md-toolbar color=&quot;primary&quot;&gt;
   &lt;span&gt;Application Title&lt;/span&gt;
 
@@ -57,12 +30,13 @@ For example, the following markup aligns the items on the <code>right</code>.</p
   &lt;span&gt;Right Aligned Text&lt;/span&gt;
 &lt;/md-toolbar&gt;
 </code></pre>
-<p>Custom SCSS</p>
 <pre><code class="lang-scss">.example-fill-remaining-space {
   // This fills the remaining space, by using flexbox. 
   // Every toolbar row uses a flexbox row layout.
   flex: 1 1 auto;
 }
 </code></pre>
-<p>Output
-<img src="https://cloud.githubusercontent.com/assets/4987015/13730760/0864894e-e959-11e5-9312-7f3cb990d80a.png" alt="image"></p>
+<h3 id="theming">Theming</h3>
+<p>The color of a <code>&lt;md-toolbar&gt;</code> can be changed by using the <code>color</code> property. By default, toolbars
+use a neutral background color based on the current theme (light or dark). This can be changed to 
+<code>&#39;primary&#39;</code>, <code>&#39;accent&#39;</code>, or <code>&#39;warn&#39;</code>.  </p>

--- a/src/assets/documents/overview/tooltip.html
+++ b/src/assets/documents/overview/tooltip.html
@@ -1,58 +1,51 @@
-<h1 id="mdtooltip">MdTooltip</h1>
-<p>Tooltip allows the user to specify text to be displayed when the mouse hovers over an element.</p>
-<p>The positions <code>before</code> and <code>after</code> should be used instead of <code>left</code> and <code>right</code> respectively when the tooltip positioning should change depending on the HTML dir global attribute for left-to-right or right-to-left layout.</p>
-<h3 id="examples">Examples</h3>
-<p>A button with a tooltip</p>
-<pre><code class="lang-html">&lt;button mdTooltip=&quot;some message&quot; mdTooltipPosition=&quot;below&quot;&gt;Button&lt;/button&gt;
-</code></pre>
-<h2 id="-mdtooltip-"><code>[mdTooltip]</code></h2>
-<h3 id="properties">Properties</h3>
+<p>The Angular Material tooltip provides a text label that is displayed with the user hovers 
+over or longpresses an element. </p>
+<div material-docs-example="tooltip-overview"></div>
+<h3 id="positioning">Positioning</h3>
+<p>The tooltip will be displayed below the element but this can be configured using the <code>mdTooltipPosition</code>
+input. 
+The tooltip can be displayed above, below, left, or right of the element. By default the position
+will be below. If the tooltip should switch left/right positions in an RTL layout direction, then
+the positions <code>before</code> and <code>after</code> should be used instead of <code>left</code> and <code>right</code>, respectively.</p>
 <table>
 <thead>
 <tr>
-<th>Name</th>
-<th>Type</th>
+<th>Position</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>mdTooltip</code></td>
-<td><code>string</code></td>
-<td>The message to be displayed.</td>
+<td><code>above</code></td>
+<td>Always display above the element</td>
 </tr>
 <tr>
-<td><code>mdTooltipPosition</code></td>
-<td>`&quot;before&quot;</td>
-<td>&quot;after&quot;</td>
-<td>&quot;above&quot;</td>
-<td>&quot;below&quot;</td>
-<td>&quot;left&quot;</td>
-<td>&quot;right&quot;`</td>
-<td>The position of the tooltip.</td>
+<td><code>below</code></td>
+<td>Always display beneath the element</td>
+</tr>
+<tr>
+<td><code>left</code></td>
+<td>Always display to the left of the element</td>
+</tr>
+<tr>
+<td><code>right</code></td>
+<td>Always display to the right of the element</td>
+</tr>
+<tr>
+<td><code>before</code></td>
+<td>Display to the left in left-to-right layout and to the right in right-to-left layout</td>
+</tr>
+<tr>
+<td><code>after</code></td>
+<td>Display to the right in left-to-right layout and to the right in right-to-left layout</td>
 </tr>
 </tbody>
 </table>
-<h3 id="methods">Methods</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>show</code></td>
-<td>Displays the tooltip.</td>
-</tr>
-<tr>
-<td><code>hide</code></td>
-<td>Removes the tooltip.</td>
-</tr>
-<tr>
-<td><code>toggle</code></td>
-<td>Displays or hides the tooltip.</td>
-</tr>
-</tbody>
-</table>
+<h3 id="showing-and-hiding">Showing and hiding</h3>
+<p>The tooltip is immediately shown when the user&#39;s mouse hovers over the element and immediately 
+hides when the user&#39;s mouse leaves. A delay in showing or hiding the tooltip can be added through
+the inputs <code>mdTooltipShowDelay</code> and <code>mdTooltipHideDelay</code>.</p>
+<p>On mobile, the tooltip is displayed when the user longpresses the element and hides after a 
+delay of 1500ms. The longpress behavior requires HammerJS to be loaded on the page.</p>
+<p>The tooltip can also be shown and hidden through the <code>show</code> and <code>hide</code> directive methods,
+which both accept a number in milliseconds to delay before applying the display change.</p>


### PR DESCRIPTION
* Add missing examples
* Add example titles
* Fix examples not being unloaded when doc-viewer is destroyed
* Update overview static content