### PR TITLE
fix: remove unnecessary components bundle

### DIFF
--- a/src/assets/plunker/index.html
+++ b/src/assets/plunker/index.html
@@ -10,9 +10,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
 
-  <!-- Load Bundle from Asset Host -->
-  <script src="https://plnkr-test.firebaseapp.com/components.bundle.js?sha=bf44c16"></script>
-
   <!-- Configure SystemJS -->
   <script src="systemjs.config.js"></script>
 
@@ -25,7 +22,7 @@
   <!-- Load the Angular Material 2 stylesheet -->
   <link href="https://unpkg.com/@angular/material/core/theming/prebuilt/indigo-pink.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <style>body { font-family: Roboto,"Helvetica Neue",sans-serif; }</style>
+  <style>body { font-family: Roboto, Arial, sans-serif; }</style>
 </head>
 
 <body>


### PR DESCRIPTION
* Removes the component bundle from the Plunker since it's unused.
* Adds `Arial` as a fallback font (as stated in material.google.com)

R: @jelbourn 