### PR TITLE
fix(scrolling): enable scrolling on safari

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -7,6 +7,10 @@ app-component-sidenav {
 
 .docs-component-viewer-sidenav-container {
   width: 100%;
+  
+  .md-sidenav-content {
+    position: absolute;
+  }
 }
 
 .docs-component-viewer-sidenav {


### PR DESCRIPTION
This is a simple one-liner that removes the `md-sidenav-content` from the flow of `md-sidenav-layout` so that layout does not derive its scroll height from the content. 

On Safari with this fix, the `md-sidenav-content` matches its bounding box client rect height and scroll height to the layout which now is correctly flex'ed to the rest of the page's height. 

Closes #71