### PR TITLE
Fixed href in Getting Started documentation

### DIFF
--- a/src/assets/documents/guides/getting-started.html
+++ b/src/assets/documents/guides/getting-started.html
@@ -22,7 +22,7 @@
 <h2 id="include-the-core-and-theme-styles-">Include the core and theme styles:</h2>
 <p>This is <strong>required</strong> to apply all of the core and theme styles to your application. You can either
 use a pre-built theme, or define your own custom theme.</p>
-<p>:trident:  See the <a href="guides/theming.md">theming guide</a> for instructions.</p>
+<p>:trident:  See the <a href="guide/theming">theming guide</a> for instructions.</p>
 <h3 id="additional-setup-for-md-slide-toggle-and-md-slider-">Additional setup for <code>md-slide-toggle</code> and <code>md-slider</code>:</h3>
 <p>The slide-toggle and slider components have a dependency on <a href="http://hammerjs.github.io/">HammerJS</a>.</p>
 <p>Add HammerJS to your application via <a href="https://www.npmjs.com/package/hammerjs">npm</a>, a CDN 


### PR DESCRIPTION
The link for the theming was broken.