### PR TITLE
docs: fix progress-bar-configurable example

### DIFF
--- a/src/app/examples/progress-bar-configurable/progress-bar-configurable-example.html
+++ b/src/app/examples/progress-bar-configurable/progress-bar-configurable-example.html
@@ -53,7 +53,7 @@
     <section class="example-section">
       <md-progress-bar
           class="example-margin"
-          [attr.color]="color"
+          [color]="color"
           [mode]="mode"
           [value]="value"
           [bufferValue]="bufferValue">

--- a/src/assets/examples/progress-bar-configurable-example-html.html
+++ b/src/assets/examples/progress-bar-configurable-example-html.html
@@ -53,7 +53,7 @@
     <span class="hljs-tag">&lt;<span class="hljs-name">section</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"example-section"</span>&gt;</span>
       <span class="hljs-tag">&lt;<span class="hljs-name">md-progress-bar</span>
           <span class="hljs-attr">class</span>=<span class="hljs-string">"example-margin"</span>
-          [<span class="hljs-attr">attr.color</span>]=<span class="hljs-string">"color"</span>
+          [<span class="hljs-attr">color</span>]=<span class="hljs-string">"color"</span>
           [<span class="hljs-attr">mode</span>]=<span class="hljs-string">"mode"</span>
           [<span class="hljs-attr">value</span>]=<span class="hljs-string">"value"</span>
           [<span class="hljs-attr">bufferValue</span>]=<span class="hljs-string">"bufferValue"</span>&gt;</span>

--- a/src/assets/plunker/examples/progress-bar-configurable/progress-bar-configurable-example.html
+++ b/src/assets/plunker/examples/progress-bar-configurable/progress-bar-configurable-example.html
@@ -53,7 +53,7 @@
     <section class="example-section">
       <md-progress-bar
           class="example-margin"
-          [attr.color]="color"
+          [color]="color"
           [mode]="mode"
           [value]="value"
           [bufferValue]="bufferValue">


### PR DESCRIPTION
* Fixes the progress-bar configurable example, where the `color` binding is set through an attribute instead of an Angular input binding.

References https://github.com/angular/material2/issues/2813

R: @kara 