### PR TITLE
fix: normalize card height

### DIFF
--- a/src/app/pages/component-category-list/component-category-list.scss
+++ b/src/app/pages/component-category-list/component-category-list.scss
@@ -16,6 +16,10 @@
   margin: 20px;
   vertical-align: top;
   cursor: pointer;
+
+  .mat-card-title {
+    font-size: 20px;
+  }
 }
 
 .docs-component-category-list-card-image {


### PR DESCRIPTION
The component group card for "Buttons, Indicators & Icons" has a wrapped title which causes the card to be larger than the others. Reduced font-size to normalize each card's title to just a one-liner