### PR TITLE
docs(list): fix list icon tag and styling

### DIFF
--- a/src/app/examples/list-sections/list-sections-example.css
+++ b/src/app/examples/list-sections/list-sections-example.css
@@ -1,1 +1,4 @@
-/** No CSS for this example */
+.mat-list-icon {
+  color: rgba(0,0,0,0.54);
+}
+

--- a/src/app/examples/list-sections/list-sections-example.html
+++ b/src/app/examples/list-sections/list-sections-example.html
@@ -1,14 +1,14 @@
 <md-list>
   <h3 md-subheader>Folders</h3>
   <md-list-item *ngFor="let folder of folders">
-    <md-icon md-list-avatar>folder</md-icon>
+    <md-icon md-list-icon>folder</md-icon>
     <h4 md-line>{{folder.name}}</h4>
     <p md-line> {{folder.updated | date}} </p>
   </md-list-item>
   <md-divider></md-divider>
   <h3 md-subheader>Notes</h3>
   <md-list-item *ngFor="let note of notes">
-    <md-icon md-list-avatar>note</md-icon>
+    <md-icon md-list-icon>note</md-icon>
     <h4 md-line>{{note.name}}</h4>
     <p md-line> {{note.updated | date}} </p>
   </md-list-item>

--- a/src/app/examples/list-sections/list-sections-example.ts
+++ b/src/app/examples/list-sections/list-sections-example.ts
@@ -3,6 +3,7 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'list-sections-example',
+  styleUrls: ['./list-sections-example.css'],
   templateUrl: './list-sections-example.html',
 })
 export class ListSectionsExample {


### PR DESCRIPTION
Fixes a typo where the icon was tagged with `md-list-avatar` instead of `md-list-icon` (already fixed in main repo).  Also changes the color of the list icon color to have better contrast for the example.