### PR TITLE
Bug (Footer): fixed visibility added red logo and made text darker

### DIFF
--- a/src/app/shared/footer/footer.html
+++ b/src/app/shared/footer/footer.html
@@ -2,7 +2,7 @@
   <div class="docs-footer-list">
     <div class="footer-logo">
       <img class="docs-footer-angular-logo"
-          src="../../../assets/img/homepage/angular-white-transparent.svg"
+          src="../../../assets/img/homepage/angular-red-transparent.svg"
           alt="Angular">
     </div>
 

--- a/src/app/shared/footer/footer.scss
+++ b/src/app/shared/footer/footer.scss
@@ -27,6 +27,7 @@
   padding: 0;
 
   a {
+    color: rgba(0,0,0,.87);
     font-size: 16px;
     padding: 0;
     text-decoration: none;

--- a/src/assets/img/homepage/angular-red-transparent.svg
+++ b/src/assets/img/homepage/angular-red-transparent.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 250 250" style="enable-background:new 0 0 250 250;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{opacity:0.9;}
+</style>
+<g>
+	<g>
+		<polygon class="st0" points="125,153.4 100.3,153.4 88.6,182.6 88.6,182.6 66.9,182.6 66.8,182.6 125,52.1 125,52.2 125,52.2 
+			125,30 125,30 31.9,63.2 46.1,186.3 125,230 125,230 125,153.4 		"/>
+		<polygon class="st0" points="108,135.4 125,135.4 125,135.4 125,94.5 		"/>
+	</g>
+	<g class="st1">
+		<polygon class="st0" points="125,153.4 149.7,153.4 161.4,182.6 161.4,182.6 183.1,182.6 183.2,182.6 125,52.1 125,52.2 125,52.2 
+			125,30 125,30 218.1,63.2 203.9,186.3 125,230 125,230 125,153.4 		"/>
+		<polygon class="st0" points="142,135.4 125,135.4 125,135.4 125,94.5 		"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
The footer text (Learn Angular) and Angular logo were practically invisible on most displays.
Added the red logo
Gave the A link a black color the same as the copy-write

closes https://github.com/angular/material2/issues/3903