### PR TITLE
Bug (Snack-bar / snackbar): fixed snackbar image not showing up

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -69,7 +69,7 @@ const DOCS = [
     items: [
       {id: 'dialog', name: 'Dialog', examples: ['dialog-result']},
       {id: 'tooltip', name: 'Tooltip', examples: ['tooltip-position']},
-      {id: 'snack-bar', name: 'Snackbar', examples: ['snack-bar-component']},
+      {id: 'snackbar', name: 'Snackbar', examples: ['snack-bar-component']},
     ]
   },
 ];


### PR DESCRIPTION
The snackbar svg is not 'snack-bar', but 'snackbar'.

Additional question.
* Snack-bar on Material.io is always one word never with a hyphen in it. a lot of times when it is referenced in this and the Angular/material2 repo its referenced as 'snack-bar' quite a bit. Is it correct either way, or should they all be either (snackbar/snack-bar) ?

![snackbar](https://cloud.githubusercontent.com/assets/1916685/24778182/146f9514-1ade-11e7-986b-9889cd240703.png)
