### PR TITLE
build: fix fetch assets local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "test": "ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
-    "build-themes": "./tools/build-themes.sh",
+    "build-themes": "bash ./tools/build-themes.sh",
     "prod-build": "npm run build-themes && ng build --aot --prod && npm run prerender && cp -r tmp/prerendered/* dist/",
-    "postinstall": "webdriver-manager update && tools/fetch-assets.sh",
+    "postinstall": "webdriver-manager update && bash ./tools/fetch-assets.sh",
     "publish-prod": "npm run build-themes && ng build --aot --prod && firebase use material-angular-io && firebase deploy",
     "publish-dev": "npm run build-themes && ng build --aot --prod && firebase use material2-docs-dev && firebase deploy"
   },

--- a/tools/fetch-assets-local.sh
+++ b/tools/fetch-assets-local.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Go to project directory
+cd $(dirname ${0})/..
+
 # Base Source Path
 if [ -d ~/material2 ] ; then
   echo "- Using path ~/material2"
@@ -21,8 +24,10 @@ fi
 # Base Target Path
 baseTargetPath=./src/assets
 
+# Path to all overview HTML files.
+overviewHtmlFiles=$(find ${baseSrcPath}/dist/docs/markdown -path "*/*.html" ! -name 'README.*')
+
 # Copy Packages
-mkdir -p ./node_modules/@angular/material-examples
 cp -r ${baseSrcPath}/dist/releases/material-examples ./node_modules/@angular/
 
 # Copy Examples
@@ -37,4 +42,4 @@ cp ${baseSrcPath}/dist/docs/markdown/*.html ${baseTargetPath}/documents/guides
 
 # Copy Overview
 mkdir -p ./src/assets/documents/overview
-cp ${baseSrcPath}/dist/docs/markdown/*/*.html ${baseTargetPath}/documents/overview
+cp ${overviewHtmlFiles} ${baseTargetPath}/documents/overview


### PR DESCRIPTION
* Currently the `fetch-assets-local` script tries to copy every `.html` file to the `src/assets` folder.
  This includes multiple `README.html` files. Bash at this point complains that there are multiple files with the same name are copied to the same destination.
* Also ensures that the CWD of the fetch script is always the root of the project.

![image](https://user-images.githubusercontent.com/4987015/27509713-34ffad7e-5903-11e7-81b0-f348c5d4f35c.png)
