### PR TITLE
fix: plunkers not including source files

### DIFF
--- a/src/app/shared/plunker/plunker-button.ts
+++ b/src/app/shared/plunker/plunker-button.ts
@@ -25,11 +25,6 @@ export class PlunkerButton {
   set example(example: string) {
     const exampleData = new ExampleData(example);
 
-    // TODO(jelbourn): remove this when bad defaults are no longer included in the source
-    exampleData.exampleFiles = [];
-    exampleData.examplePath = '';
-    exampleData.indexFilename = '';
-
     this.plunkerWriter.constructPlunkerForm(exampleData).then(plunkerForm => {
       this.plunkerForm = plunkerForm;
       this.isDisabled = false;


### PR DESCRIPTION
* Fixes that the Plunker form does not contain the source-files from the associated example.

Fixes https://github.com/angular/material2/issues/5245