### PR TITLE
fix: site crashing on browsers with limited localStorage access

### DIFF
--- a/src/app/shared/theme-picker/theme-storage/theme-storage.ts
+++ b/src/app/shared/theme-picker/theme-storage/theme-storage.ts
@@ -6,7 +6,7 @@ export interface DocsSiteTheme {
   primary: string;
   isDark?: boolean;
   isDefault?: boolean;
-};
+}
 
 
 @Injectable()
@@ -16,15 +16,24 @@ export class ThemeStorage {
   public onThemeUpdate: EventEmitter<DocsSiteTheme> = new EventEmitter<DocsSiteTheme>();
 
   public storeTheme(theme: DocsSiteTheme) {
-    window.localStorage[ThemeStorage.storageKey] = JSON.stringify(theme);
+    try {
+      window.localStorage[ThemeStorage.storageKey] = JSON.stringify(theme);
+    } catch (e) { }
+
     this.onThemeUpdate.emit(theme);
   }
 
   public getStoredTheme(): DocsSiteTheme {
-    return JSON.parse(window.localStorage[ThemeStorage.storageKey] || null);
+    try {
+      return JSON.parse(window.localStorage[ThemeStorage.storageKey] || null);
+    } catch (e) {
+      return null;
+    }
   }
 
   public clearStorage() {
-    window.localStorage.removeItem(ThemeStorage.storageKey);
+    try {
+      window.localStorage.removeItem(ThemeStorage.storageKey);
+    } catch (e) { }
   }
 }


### PR DESCRIPTION
Prevents the site from crashing on browsers that don't allow access to localStorage (e.g. IE11 or iOS Safari in private mode).