### PR TITLE
docs(demos): updates dialog example to overivew

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -68,7 +68,7 @@ const DOCS = [
     name: 'Popups & Modals',
     summary: 'Dialogs, tooltips, snackbars',
     items: [
-      {id: 'dialog', name: 'Dialog', examples: ['dialog-result']},
+      {id: 'dialog', name: 'Dialog', examples: ['dialog-overview']},
       {id: 'tooltip', name: 'Tooltip', examples: ['tooltip-position']},
       {id: 'snack-bar', name: 'Snackbar', examples: ['snack-bar-component']},
     ]


### PR DESCRIPTION
This updates the example in the documentation to the new overview example.

https://github.com/angular/material2/pull/5666/