### PR TITLE
fix(categories): make list items anchors like component list items

### DIFF
--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -1,9 +1,10 @@
 <div class="docs-component-category-list">
-  <md-card
-      *ngFor="let category of docItems.getItemsInCategories()"
-      class="docs-component-category-list-card"
-      [routerLink]="['/categories/', category.id]">
-    <md-card-title>{{category.name}}</md-card-title>
-    <p class="docs-component-category-list-card-summary">{{category.summary}}</p>
-  </md-card>
+  <a *ngFor="let category of docItems.getItemsInCategories()"
+    class="docs-component-category-list-item"
+    [routerLink]="['/categories/', category.id]">
+    <md-card class="docs-component-category-list-card">
+      <md-card-title>{{category.name}}</md-card-title>
+      <p class="docs-component-category-list-card-summary">{{category.summary}}</p>
+    </md-card>
+  </a>
 </div>

--- a/src/app/pages/component-category-list/component-category-list.scss
+++ b/src/app/pages/component-category-list/component-category-list.scss
@@ -10,8 +10,7 @@
   }
 }
 
-.docs-component-category-list-card {
-  cursor: pointer;
+.docs-component-category-list-item {
   display: inline-block;
   margin: 20px;
   vertical-align: top;
@@ -19,6 +18,10 @@
 
   .mat-card-title {
     font-size: 20px;
+  }
+
+  &, &:active, &:hover, &:focus {
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
This matches the category list behavior to the component list. Before, it was not possible to navigate the list by focusing a card and pressing <kbd>enter</kbd>