### PR TITLE
fix(navbar): shadow and routing

### DIFF
--- a/src/app/app-module.ts
+++ b/src/app/app-module.ts
@@ -48,7 +48,6 @@ import {DocViewerModule} from './shared/doc-viewer/doc-viewer-module';
     DocViewerModule,
     FooterModule,
     GuideListModule,
-    GuideListModule,
     GuideViewerModule,
     HomepageModule,
     NavBarModule,

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -1,5 +1,6 @@
 import {Component, ViewEncapsulation} from '@angular/core';
-import {Router, NavigationStart} from '@angular/router';
+import {Router, NavigationEnd} from '@angular/router';
+import 'rxjs/add/operator/filter';
 
 
 @Component({
@@ -14,17 +15,19 @@ export class MaterialDocsApp {
   constructor(router: Router) {
     let previousRoute = router.routerState.snapshot.url;
 
-    router.events.subscribe((data: NavigationStart) => {
-      this.showShadow = /^\/(categories|components)/.test(data.url);
+    router.events
+      .filter(event => event instanceof NavigationEnd )
+      .subscribe((data: NavigationEnd) => {
+        this.showShadow = /^\/(categories|components)/.test(data.urlAfterRedirects);
 
-      // We want to reset the scroll position on navigation except when navigating within
-      // the documentation for a single component.
-      if (!isNavigationWithinComponentView(previousRoute, data.url)) {
-        resetScrollPosition();
-      }
+        // We want to reset the scroll position on navigation except when navigating within
+        // the documentation for a single component.
+        if (!isNavigationWithinComponentView(previousRoute, data.urlAfterRedirects)) {
+          resetScrollPosition();
+        }
 
-      previousRoute = data.url;
-    });
+        previousRoute = data.urlAfterRedirects;
+      });
   }
 }
 

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -13,12 +13,15 @@ export class MaterialDocsApp {
   showShadow = false;
 
   constructor(router: Router) {
+    const routesWithNavbarShadow = ['/categories', '/components'];
+
     let previousRoute = router.routerState.snapshot.url;
 
     router.events
       .filter(event => event instanceof NavigationEnd )
       .subscribe((data: NavigationEnd) => {
-        this.showShadow = /^\/(categories|components)/.test(data.urlAfterRedirects);
+        this.showShadow = !!routesWithNavbarShadow
+            .find(route => data.urlAfterRedirects.startsWith(route));
 
         // We want to reset the scroll position on navigation except when navigating within
         // the documentation for a single component.

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -15,7 +15,7 @@ export class MaterialDocsApp {
     let previousRoute = router.routerState.snapshot.url;
 
     router.events.subscribe((data: NavigationStart) => {
-      this.showShadow = data.url.startsWith('/components');
+      this.showShadow = /^\/(categories|components)/.test(data.url);
 
       // We want to reset the scroll position on navigation except when navigating within
       // the documentation for a single component.

--- a/src/app/pages/homepage/homepage.html
+++ b/src/app/pages/homepage/homepage.html
@@ -5,7 +5,7 @@
       <h2> Material Design components for Angular</h2>
     </div>
     <div class="docs-header-start">
-     <a md-raised-button class="docs-button" routerLink="guide/getting-started">Get started</a>
+     <a md-raised-button class="docs-button" routerLink="/guide/getting-started">Get started</a>
     </div>
   </div>
 </header>
@@ -59,7 +59,7 @@
     </div>
   </div>
   <div class="docs-homepage-bottom-start">
-    <a md-raised-button class="docs-button" routerLink="guide/getting-started">Get started</a>
+    <a md-raised-button class="docs-button" routerLink="/guide/getting-started">Get started</a>
   </div>
 </div>
 


### PR DESCRIPTION
- Navbar shadow wasn't being shown at [`/categories/forms`](https://material.angular.io/categories/forms) due to only checking for `/components` in the start of the url
- Check only one navigation event (end) and `urlAfterRedirects` when setting shadow/scoll-position (prevents bug where going to [`/componentsfoo`](https://material.angular.io/componentsfoo) results in improper shadow)
- Fix bug where GET STARTED links break after a redirect to the homepage

The last one is weird. If you go to [`/foo`](https://material.angular.io/foo) and are redirected back to the homepage, the GET STARTED url is serialized improperly. It looks like some issue with `ApplyRedirects#apply` and I'm pretty sure is a bug in core. The fix is to use an absolute path.