### PR TITLE
fix(source-viewer): Move docs-example-source styles to the appropriate component

### DIFF
--- a/src/app/pages/component-viewer/_component-viewer-theme.scss
+++ b/src/app/pages/component-viewer/_component-viewer-theme.scss
@@ -16,8 +16,4 @@
     }
 
   }
-
-  .docs-example-source {
-    border-bottom: 1px solid mat-color($foreground, divider);
-  }
 }

--- a/src/app/pages/component-viewer/component-viewer.scss
+++ b/src/app/pages/component-viewer/component-viewer.scss
@@ -26,8 +26,3 @@ app-component-viewer {
 .docs-component-viewer-content {
   min-height: 500px;
 }
-
-.docs-example-source {
-  padding: 0 0 10px 30px;
-  min-height: 150px;
-}

--- a/src/app/shared/example-viewer/_example-viewer-theme.scss
+++ b/src/app/shared/example-viewer/_example-viewer-theme.scss
@@ -16,5 +16,9 @@
       color: mat-color($foreground, secondary-text);
       background: rgba(mat-color($foreground, secondary-text), .03);
     }
+
+    .docs-example-source {
+      border-bottom: 1px solid mat-color($foreground, divider);
+    }
   }
 }

--- a/src/app/shared/example-viewer/example-viewer.scss
+++ b/src/app/shared/example-viewer/example-viewer.scss
@@ -20,6 +20,11 @@
   flex: 1 1 auto;
 }
 
+.docs-example-source {
+  padding: 0 0 10px 30px;
+  min-height: 150px;
+}
+
 .docs-example-viewer-body {
   padding: 30px;
 }


### PR DESCRIPTION
Fixes a bug where if you open the [cdk guide source viewer](https://material.angular.io/guide/cdk-table) without previously loading a component, there is no padding.