### PR TITLE
Fix: Table of contents show the word "link" on IE and Edge

### DIFF
--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -105,7 +105,7 @@ export class TableOfContents implements OnInit {
     if (headers.length) {
       for (const header of headers) {
         // remove the 'link' icon name from the inner text
-        const name = header.innerText.replace(/^link/, '');
+        const name = header.innerText.trim().replace(/^link/, '');
         const {top} = header.getBoundingClientRect();
         links.push({
           name,


### PR DESCRIPTION
Fixes #250