### PR TITLE
docs(style): apply list styling

### DIFF
--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -24,7 +24,9 @@
   font-size: 18px;
 }
 
-.docs-markdown-p {
+.docs-markdown-p,
+.docs-markdown-ul,
+.docs-markdown-ol {
   font-size: 16px;
   line-height: 28px;
 }


### PR DESCRIPTION
Small styling addition for lists to keep them the same as paragraphs (`font-size` and `line-height`). 

This fixes #254.