### PR TITLE
fix(toc): highlight wrong item on jump #256

### DIFF
--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -58,7 +58,11 @@ export class TableOfContents implements OnInit {
 
     this._fragmentSubscription = this._route.fragment.subscribe(fragment => {
       this._urlFragment = fragment;
-      this.updateScrollPosition();
+
+      const target = document.getElementById(this._urlFragment);
+      if (target) {
+        target.scrollIntoView();
+      }
     });
   }
 


### PR DESCRIPTION
On the icon page, when you click a link such as 'SVG Icons', the wrong link is highlighted. The culprit is the links are re-generated when jumping with the wrong offsets. Additionally, the links do NOT need to be regenerated when jumping on the same page so this improves that performance too.

This addresses #256