### PR TITLE
fix: center guide viewer and remove outline from focused header

### DIFF
--- a/src/app/pages/component-page-header/component-page-header.scss
+++ b/src/app/pages/component-page-header/component-page-header.scss
@@ -10,6 +10,8 @@
 }
 
 h1 {
+  outline: none;
+
   @media (max-width: $small-breakpoint-width) {
     padding: 24px 8px;
     font-size: 20px;

--- a/src/app/pages/guide-viewer/guide-viewer.scss
+++ b/src/app/pages/guide-viewer/guide-viewer.scss
@@ -26,6 +26,7 @@ $guide-content-margin-side-xs: 15px;
   display: block;
   text-align: left;
   max-width: 940px;
+  margin: 0 auto;
 }
 
 .docs-guide-content {


### PR DESCRIPTION
* Fixes bug where guides were no longer centered on wide viewports
* Fixes https://github.com/angular/material.angular.io/issues/269

cc @jelbourn 