### PR TITLE
Fixes API Docs Formatting

### DIFF
--- a/src/app/pages/component-viewer/component-api.scss
+++ b/src/app/pages/component-viewer/component-api.scss
@@ -1,0 +1,19 @@
+.docs-api-class-name {
+  margin-top: 24px;
+  margin-bottom: 0;
+  display: inline-block;
+}
+
+.docs-api-h3 {
+  margin-bottom: 0;
+}
+
+.docs-api-class-export-label,
+.docs-api-directive-selectors,
+.docs-api-class-description {
+  font-size: 14px;
+}
+
+.docs-api-class-deprecated-marker {
+  font-weight: bold;
+}

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -52,6 +52,7 @@ export class ComponentOverview implements OnInit {
 @Component({
   selector: 'component-api',
   templateUrl: './component-api.html',
+  styleUrls: ['./component-api.scss'],
   encapsulation: ViewEncapsulation.None,
 })
 export class ComponentApi extends ComponentOverview {}


### PR DESCRIPTION
This PR adds the better spacing to the API docs.

![img](https://content.screencast.com/users/amcdaniel22/folders/Snagit/media/c2a8f36e-140e-450a-a666-c4d983ebc17c/2017-10-01_13-24-29.png)

Relies on: https://github.com/angular/material2/pull/7457