### PR TITLE
fix: fix components and CDK categories page title

### DIFF
--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -1,7 +1,7 @@
 <div class="docs-component-category-list">
-  <a *ngFor="let category of docItems.getCategories((params | async)?.section)"
+  <a *ngFor="let category of categories"
      class="docs-component-category-list-item"
-    [routerLink]="['../', category.id]">
+    [routerLink]="['/', section, category.id]">
     <mat-card class="docs-component-category-list-card">
       <mat-card-title>{{category.name}}</mat-card-title>
     </mat-card>

--- a/src/app/pages/component-category-list/component-category-list.spec.ts
+++ b/src/app/pages/component-category-list/component-category-list.spec.ts
@@ -1,40 +1,89 @@
 import {async, ComponentFixture, TestBed, inject} from '@angular/core/testing';
-import {Router} from '@angular/router';
-import {Observable} from 'rxjs/Observable'
+import {ActivatedRoute} from '@angular/router';
 import {ComponentCategoryList, ComponentCategoryListModule} from './component-category-list';
 import {DocsAppTestingModule} from '../../testing/testing-module';
+import {SECTIONS} from '../../shared/documentation-items/documentation-items';
+import {ComponentPageTitle} from '../page-title/page-title';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
 
+const COMPONENTS_SECTION = 'components';
+const CDK_SECTION = 'cdk';
 
 describe('ComponentCategoryList', () => {
   let fixture: ComponentFixture<ComponentCategoryList>;
+  let componentPageTitle: ComponentPageTitle;
+  let currentSectionId: BehaviorSubject<string>;
 
   beforeEach(async(() => {
+    currentSectionId = new BehaviorSubject<string>(COMPONENTS_SECTION);
+    const mockActivatedRoute = {
+      pathFromRoot: [{
+        params: currentSectionId.map(sectionId => {
+          return { section: sectionId };
+        })
+      }]
+    };
+
     TestBed.configureTestingModule({
       imports: [ComponentCategoryListModule, DocsAppTestingModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute }
+      ]
     }).compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(inject([ComponentPageTitle], (cpt: ComponentPageTitle) => {
     fixture = TestBed.createComponent(ComponentCategoryList);
+    componentPageTitle = cpt;
+  }));
+
+  afterEach(() => {
+    currentSectionId.complete();
   });
 
-  it('should set set up base param observable on init', () => {
+  it('should set up properties on init', () => {
     const component = fixture.componentInstance;
     spyOn(component, 'ngOnInit').and.callThrough();
     fixture.detectChanges();
     expect(component.ngOnInit).toHaveBeenCalled();
-    expect(component.params).toBeDefined();
+    expect(component.categories).toBeDefined();
+  });
+
+  it('should set the section', () => {
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    expect(component.section).toEqual(COMPONENTS_SECTION);
+
+    currentSectionId.next(CDK_SECTION);
+    fixture.detectChanges();
+    expect(component.section).toEqual(CDK_SECTION);
+  });
+
+  it('should set the title', () => {
+    componentPageTitle.title = 'abc';
+    fixture.detectChanges();
+    expect(componentPageTitle.title).toEqual(SECTIONS[COMPONENTS_SECTION]);
+
+    currentSectionId.next(CDK_SECTION);
+    fixture.detectChanges();
+    expect(componentPageTitle.title).toEqual(SECTIONS[CDK_SECTION]);
   });
 
   it('should render a card for every category', () => {
-    fixture.detectChanges();
-    // Params is replaced after ngOnit runs since params is set on init.
-    fixture.componentInstance.params = Observable.of({'section': 'components'});
-    fixture.detectChanges();
     const component = fixture.componentInstance;
-    const categories = component.docItems.getCategories('components');
-    const cards = fixture
+    fixture.detectChanges();
+    const categories1 = component.docItems.getCategories(COMPONENTS_SECTION);
+    const cards1 = fixture
       .nativeElement.querySelectorAll('.docs-component-category-list-card');
-    expect(cards.length).toEqual(categories.length);
+    expect(cards1.length).toEqual(categories1.length);
+
+    currentSectionId.next(CDK_SECTION);
+    fixture.detectChanges();
+    const categories2 = component.docItems.getCategories(CDK_SECTION);
+    const cards2 = fixture
+      .nativeElement.querySelectorAll('.docs-component-category-list-card');
+    expect(cards2.length).toEqual(categories2.length);
   });
 });

--- a/src/app/pages/component-category-list/component-category-list.ts
+++ b/src/app/pages/component-category-list/component-category-list.ts
@@ -1,4 +1,4 @@
-import {Component, NgModule, OnInit} from '@angular/core';
+import {Component, NgModule, OnInit, OnDestroy} from '@angular/core';
 import {MatCardModule} from '@angular/material';
 import {CommonModule} from '@angular/common';
 import {ActivatedRoute, RouterModule} from '@angular/router';
@@ -19,10 +19,10 @@ import 'rxjs/add/operator/combineLatest';
   templateUrl: './component-category-list.html',
   styleUrls: ['./component-category-list.scss']
 })
-export class ComponentCategoryList implements OnInit {
+export class ComponentCategoryList implements OnInit, OnDestroy {
   section: string;
   categories: DocCategory[];
-  _titleUpdateSubscription: Subscription;
+  private _sectionUpdateSubscription: Subscription;
 
   constructor(public docItems: DocumentationItems,
               public _componentPageTitle: ComponentPageTitle,
@@ -30,13 +30,17 @@ export class ComponentCategoryList implements OnInit {
 
   ngOnInit() {
     // Combine params from all of the path into a single object.
-    Observable
+    this._sectionUpdateSubscription = Observable
       .combineLatest(this._route.pathFromRoot.map(route => route.params), Object.assign)
       .subscribe(params => {
         this.section = params['section'];
         this.categories = this.docItems.getCategories(this.section);
         this._componentPageTitle.title = SECTIONS[this.section];
       });
+  }
+
+  ngOnDestroy() {
+    this._sectionUpdateSubscription.unsubscribe();
   }
 }
 

--- a/src/app/pages/component-category-list/component-category-list.ts
+++ b/src/app/pages/component-category-list/component-category-list.ts
@@ -1,12 +1,17 @@
 import {Component, NgModule, OnInit} from '@angular/core';
 import {MatCardModule} from '@angular/material';
 import {CommonModule} from '@angular/common';
-import {ActivatedRoute, Params, RouterModule} from '@angular/router';
-import {DocumentationItems, SECTIONS} from '../../shared/documentation-items/documentation-items';
+import {ActivatedRoute, RouterModule} from '@angular/router';
+import {
+  DocumentationItems,
+  SECTIONS,
+  DocCategory
+} from '../../shared/documentation-items/documentation-items';
 import {ComponentPageTitle} from '../page-title/page-title';
 import {SvgViewerModule} from '../../shared/svg-viewer/svg-viewer';
 import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/combineLatest';
+import {Subscription} from 'rxjs/Subscription';
+import 'rxjs/add/operator/combineLatest';
 
 
 @Component({
@@ -15,17 +20,23 @@ import 'rxjs/add/observable/combineLatest';
   styleUrls: ['./component-category-list.scss']
 })
 export class ComponentCategoryList implements OnInit {
-  params: Observable<Params>;
+  section: string;
+  categories: DocCategory[];
+  _titleUpdateSubscription: Subscription;
 
   constructor(public docItems: DocumentationItems,
               public _componentPageTitle: ComponentPageTitle,
-              private _route: ActivatedRoute) {}
+              public _route: ActivatedRoute) {}
 
   ngOnInit() {
     // Combine params from all of the path into a single object.
-    this.params = Observable.combineLatest(
-      this._route.pathFromRoot.map(route => route.params),
-      Object.assign);
+    Observable
+      .combineLatest(this._route.pathFromRoot.map(route => route.params), Object.assign)
+      .subscribe(params => {
+        this.section = params['section'];
+        this.categories = this.docItems.getCategories(this.section);
+        this._componentPageTitle.title = SECTIONS[this.section];
+      });
   }
 }
 

--- a/src/app/pages/component-category-list/component-category-list.ts
+++ b/src/app/pages/component-category-list/component-category-list.ts
@@ -26,7 +26,7 @@ export class ComponentCategoryList implements OnInit {
 
   constructor(public docItems: DocumentationItems,
               public _componentPageTitle: ComponentPageTitle,
-              public _route: ActivatedRoute) {}
+              private _route: ActivatedRoute) {}
 
   ngOnInit() {
     // Combine params from all of the path into a single object.


### PR DESCRIPTION
This PR fixes the bug on where the title and the primary header is currently not set when nagivating to https://material.angular.io/components/categories and https://material.angular.io/cdk/categories.

