### PR TITLE
style(guide-list): remove margin on small screens

### DIFF
--- a/src/app/pages/guide-list/guide-list.scss
+++ b/src/app/pages/guide-list/guide-list.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/constants';
+
 :host {
   display: flex;
   flex-direction: column;
@@ -5,8 +7,12 @@
 }
 
 .docs-guide-list {
-  margin: 50px;
   flex-grow: 1;
+  margin: $content-padding-side;
+
+  @media (max-width: $small-breakpoint-width) {
+    margin: 0;
+  }
 }
 
 .docs-guide-item, .docs-guide-item:hover {


### PR DESCRIPTION
- This allows the nav-list to reach full width of container on small screen
- In wide screens, this increases the margin to better match other constants in the app


![screen shot 2017-11-01 at 12 26 02 pm](https://user-images.githubusercontent.com/6475576/32284918-212a8be0-beff-11e7-984b-35f02e00ba31.png)

cc @jelbourn 