### PR TITLE
docs(datepicker): fix URL fragment issue

### DIFF
--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -15,6 +15,7 @@ import {Subscription} from 'rxjs/Subscription';
 import {ExampleViewer} from '../example-viewer/example-viewer';
 import {HeaderLink} from './header-link';
 import {ComponentPortal, DomPortalHost} from '@angular/cdk/portal';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'doc-viewer',
@@ -40,7 +41,8 @@ export class DocViewer implements OnDestroy {
               private _elementRef: ElementRef,
               private _http: Http,
               private _injector: Injector,
-              private _viewContainerRef: ViewContainerRef) {}
+              private _viewContainerRef: ViewContainerRef,
+              private _router: Router) {}
 
   /** Fetch a document by URL. */
   private _fetchDocument(url: string) {
@@ -53,7 +55,9 @@ export class DocViewer implements OnDestroy {
         response => {
           // TODO(mmalerba): Trust HTML.
           if (response.ok) {
-            this._elementRef.nativeElement.innerHTML = response.text();
+            const currentUrl = this._router.url.split('#')[0];
+            this._elementRef.nativeElement.innerHTML =
+              response.text().replace(/href="(#\D*?)"/g, `href='${currentUrl}$1'`);
             this.textContent = this._elementRef.nativeElement.textContent;
             this._loadComponents('material-docs-example', ExampleViewer);
             this._loadComponents('header-link', HeaderLink);


### PR DESCRIPTION
Currently, there are issues for the URL fragments in the datepicker overview document, three places:
1. 
![image](https://user-images.githubusercontent.com/8519685/32492475-61938114-c3f5-11e7-8f26-b366b4dfd01a.png)
2.
![image](https://user-images.githubusercontent.com/8519685/32492494-6d2c1fae-c3f5-11e7-9c50-811d492e3172.png)
3. 
![image](https://user-images.githubusercontent.com/8519685/32492515-810bd96a-c3f5-11e7-9813-6d3523bb6e44.png)
Their HTML like this:
```HTML
<a href="#choosing-a-date-implementation-and-date-format-settings" class="docs-markdown-a"><em>Choosing a date implementation</em></a>
``` 
So here I fixed these URLs in the a tag, like the ones in the right floating table.
After fix, the result is 
```HTML
<a href="/components/datepicker/overview#customizing-the-parse-and-display-formats" class="docs-markdown-a"><em>Customizing the parse and display formats</em></a>
``` 