### PR TITLE
fix link to this heading visibility on focus

### DIFF
--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -76,7 +76,8 @@ pre {
     visibility: hidden;
   }
 
-  &:hover .material-icons {
+  &:hover .material-icons,
+  &:focus .material-icons {
     visibility: visible;
   }
 }


### PR DESCRIPTION
Fixes the issue when tabbing through the documentation and you focus the heading anchor the icon is not visible.

Before:
![image](https://user-images.githubusercontent.com/10200431/32611744-4f81aa54-c55e-11e7-87c7-9abd6db6c1f0.png)

After:
![image](https://user-images.githubusercontent.com/10200431/32611768-61bdd1e8-c55e-11e7-854e-93fd5cf3d49d.png)
