### PR TITLE
fix(table): http example needs httpclientmodule

### DIFF
--- a/src/assets/stackblitz/main.ts
+++ b/src/assets/stackblitz/main.ts
@@ -39,6 +39,7 @@ import {
 } from '@angular/material';
 import {MaterialDocsExample} from './app/material-docs-example';
 import {HttpModule} from '@angular/http';
+import {HttpClientModule} from '@angular/common/http';
 import {CdkTableModule} from '@angular/cdk/table';
 
 @NgModule({
@@ -86,6 +87,7 @@ export class DemoMaterialModule {}
     BrowserAnimationsModule,
     FormsModule,
     HttpModule,
+    HttpClientModule,
     DemoMaterialModule,
     MatNativeDateModule,
     ReactiveFormsModule,


### PR DESCRIPTION
Current example is broken since it requires the new Http module.

Fixes #339 