### PR TITLE
fix: forcing scroll in app-component-sidenav

### DIFF
--- a/src/app/material-docs-app.scss
+++ b/src/app/material-docs-app.scss
@@ -22,7 +22,8 @@ material-docs-app > app-component-sidenav {
 
 material-docs-app > app-homepage,
 material-docs-app > app-guides,
-material-docs-app > guide-viewer {
+material-docs-app > guide-viewer,
+material-docs-app > app-component-sidenav {
   overflow-y: auto;
 }
 
@@ -33,7 +34,8 @@ material-docs-app > guide-viewer {
 
   material-docs-app > app-homepage,
   material-docs-app > app-guides,
-  material-docs-app > guide-viewer {
+  material-docs-app > guide-viewer,
+  material-docs-app > app-component-sidenav {
     overflow-y: visible;
   }
 }


### PR DESCRIPTION
This changes will force scrolling inside `app-component-sidenav` and the page layout will be the same across all browsers (Firefox and Edge will get sticky `toc` and fixed scrollbar  `sidenav`)

fixes #257, fixes #285