### PR TITLE
chore: update guides to no longer include cdk-table

### DIFF
--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -19,6 +19,9 @@ export const MATERIAL_DOCS_ROUTES: Routes = [
   {path: '', component: Homepage, pathMatch: 'full', data: {}},
   {path: 'categories', redirectTo: '/components/categories'},
   {path: 'guides', component: GuideList, data: {}},
+  // Since https://github.com/angular/material2/pull/9574, the cdk-table guide became the overview
+  // document for the cdk table. To avoid any dead / broken links, we redirect to the new location.
+  {path: 'guide/cdk-table', redirectTo: '/cdk/table/overview'},
   {path: 'guide/:id', component: GuideViewer, data: {}},
   {
     path: ':section',

--- a/src/app/shared/guide-items/guide-items.ts
+++ b/src/app/shared/guide-items/guide-items.ts
@@ -28,11 +28,6 @@ const GUIDES = [
     document: '/assets/documents/guides/material-typography.html',
   },
   {
-    id: 'cdk-table',
-    name: `CDK data-table`,
-    document: '/assets/documents/guides/material-cdk-table.html',
-  },
-  {
     id: 'customizing-component-styles',
     name: 'Customizing component styles',
     document: '/assets/documents/guides/material-customizing-component-styles.html'


### PR DESCRIPTION
* The cdk-table guide became the overview document for the cdk table component. Therefore it's no longer a guide.