### PR TITLE
better styling for deprecated api items

### DIFF
--- a/src/app/pages/component-viewer/component-api.scss
+++ b/src/app/pages/component-viewer/component-api.scss
@@ -34,10 +34,6 @@
   line-height: 24px;
 }
 
-.docs-api-class-deprecated-marker {
-  font-weight: bold;
-}
-
 .docs-api-property-type {
   font-weight: bold;
   font-size: 14px;

--- a/src/styles/_api.scss
+++ b/src/styles/_api.scss
@@ -56,7 +56,8 @@
 }
 
 .docs-api-input-marker,
-.docs-api-output-marker {
+.docs-api-output-marker,
+.docs-api-deprecated-marker {
   // Size corresponding to "caption"-style text in the spec.
   font-size: 12px;
 }
@@ -66,4 +67,20 @@
 .docs-api-class-export-name {
   font-family: 'Roboto Mono', monospace;
   padding: 3px;
+}
+
+.docs-api-deprecated-marker,
+.docs-api-class-deprecated-marker,
+.docs-api-interface-deprecated-marker {
+  display: inline-block;
+  font-weight: bold;
+
+  &[title] {
+    border-bottom: 1px dotted grey;
+    cursor: help;
+  }
+}
+
+.docs-api-deprecated-marker + .docs-api-property-name {
+  text-decoration: line-through;
 }


### PR DESCRIPTION
* Adds a dotted underline to the `Deprecated` markers. Those can be hovered to see more information about the deprecation / deletion.
* Fixes that the deprecation markers are too big and are not looking good in the API table
* Adds a line through property names that are also deprecated. This makes it clear that this API is deprecated and also looks pretty good.

![image](https://user-images.githubusercontent.com/4987015/35872221-9913ac3c-0b66-11e8-9cc2-2195b7c8a2a9.png)

References https://github.com/angular/material2/pull/9648