### PR TITLE
chore: add bottom sheet examples

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -154,6 +154,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
       id: 'modals',
       name: 'Popups & Modals',
       items: [
+        {id: 'bottom-sheet', name: 'Bottom Sheet', examples: ['bottom-sheet-overview']},
         {id: 'dialog', name: 'Dialog', examples: ['dialog-overview']},
         {id: 'snack-bar', name: 'Snackbar', examples: ['snack-bar-component']},
         {id: 'tooltip', name: 'Tooltip', examples: ['tooltip-position']},

--- a/src/assets/stackblitz/main.ts
+++ b/src/assets/stackblitz/main.ts
@@ -7,6 +7,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpModule} from '@angular/http';
 import {
   MatAutocompleteModule,
+  MatBottomSheetModule,
   MatButtonModule,
   MatButtonToggleModule,
   MatCardModule,
@@ -48,6 +49,7 @@ import {MaterialDocsExample} from './app/material-docs-example';
   exports: [
     CdkTableModule,
     MatAutocompleteModule,
+    MatBottomSheetModule,
     MatButtonModule,
     MatButtonToggleModule,
     MatCardModule,


### PR DESCRIPTION
Adds the bottom sheet examples to the navigation and includes the bottom sheet module.

Related Material PR: https://github.com/angular/material2/pull/9809