### PR TITLE
fix: markdown docs overlap

### DIFF
--- a/src/styles/_general.scss
+++ b/src/styles/_general.scss
@@ -27,6 +27,10 @@ code {
   font-size: 90%;
 }
 
+.docs-markdown {
+  width: 100%;
+}
+
 .docs-markdown-pre code {
   font-size: 100%;
 }


### PR DESCRIPTION
The docs overlap the right sidenav as seen at angular/material2#9951