### PR TITLE
fix(stackblitz): fix svg path getting extra /app

### DIFF
--- a/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -114,7 +114,14 @@ export class StackblitzWriter {
     form.appendChild(input);
   }
 
-  /** Reads the file and adds its text to the form */
+  /**
+   * Reads the file and adds its text to the form
+   * @param form the html form you are appending to
+   * @param data example metadata about the example
+   * @param filename file name of the example
+   * @param path path to the src
+   * @param prependApp whether to prepend the 'app' prefix to the path
+   */
   _readFile(form: HTMLFormElement,
             data: ExampleData,
             filename: string,
@@ -125,7 +132,15 @@ export class StackblitzWriter {
       error => console.log(error));
   }
 
-  /** Adds the file text to the form. */
+  /**
+   * Adds the file text to the form.
+   * @param form the html form you are appending to
+   * @param data example metadata about the example
+   * @param content file contents
+   * @param filename file name of the example
+   * @param path path to the src
+   * @param prependApp whether to prepend the 'app' prefix to the path
+   */
   _addFileToForm(form: HTMLFormElement,
                  data: ExampleData,
                  content: string,

--- a/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -87,7 +87,7 @@ export class StackblitzWriter {
 
       // TODO(josephperrott): Prevent including assets to be manually checked.
       if (data.selectorName === 'icon-svg-example') {
-        this._readFile(form, data, 'assets/img/examples/thumbup-icon.svg', '');
+        this._readFile(form, data, 'assets/img/examples/thumbup-icon.svg', '', false);
       }
 
       Promise.all(templateContents.concat(exampleContents)).then(() => {
@@ -115,9 +115,13 @@ export class StackblitzWriter {
   }
 
   /** Reads the file and adds its text to the form */
-  _readFile(form: HTMLFormElement, data: ExampleData, filename: string, path: string): void {
+  _readFile(form: HTMLFormElement,
+            data: ExampleData,
+            filename: string,
+            path: string,
+            prependApp = true): void {
     this._http.get(path + filename).toPromise().then(
-      response => this._addFileToForm(form, data, response.text(), filename, path),
+      response => this._addFileToForm(form, data, response.text(), filename, path, prependApp),
       error => console.log(error));
   }
 
@@ -126,10 +130,11 @@ export class StackblitzWriter {
                  data: ExampleData,
                  content: string,
                  filename: string,
-                 path: string) {
+                 path: string,
+                 prependApp = true) {
     if (path == TEMPLATE_PATH) {
       content = this._replaceExamplePlaceholderNames(data, filename, content);
-    } else {
+    } else if (prependApp) {
       filename = 'app/' + filename;
     }
     this._appendFormInput(form, `files[${filename}]`, this._appendCopyright(filename, content));


### PR DESCRIPTION
This PR fixes the SVG demo not getting the correct path. There is still an issue with the SVG not being resolved though. Reached out to Eric regarding.

See: https://stackblitz.com/edit/angular-niug11?file=app/icon-svg-example.ts