### PR TITLE
fix(component-viewer): can't navigate to CDK after visiting component

### DIFF
--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -28,16 +28,16 @@ export class ComponentViewer {
     // parent route for the section (material/cdk).
     combineLatest(_route.params, _route.parent.params).pipe(
         map((p: [Params, Params]) => ({id: p[0]['id'], section: p[1]['section']})),
-        map(p => docItems.getItemById(p.id, p.section))).subscribe(d => {
-          this.componentDocItem = d;
+        map(p => ({doc: docItems.getItemById(p.id, p.section), section: p.section}))
+        ).subscribe(d => {
+          this.componentDocItem = d.doc;
           if (this.componentDocItem) {
             this._componentPageTitle.title = `${this.componentDocItem.name}`;
             this.componentDocItem.examples.length ?
                 this.sections.add('examples') :
                 this.sections.delete('examples');
-
           } else {
-            this.router.navigate(['/components']);
+            this.router.navigate(['/' + d.section]);
           }
         });
   }


### PR DESCRIPTION
fix #327,
In the component-viewer, use id and section to check the navigation, but when the id and section is not matched, it always navigated to the Component page, so here is the issue: when navigating between Component page and CDK page, when the id is existed and not matched with section, always navigate to the Component page.

@jelbourn @mmalerba hope you can help me review, thanks