### PR TITLE
fix: include all menu examples under examples tab

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -104,7 +104,15 @@ const DOCS: {[key: string]: DocCategory[]} = {
       name: 'Navigation',
       summary: 'Sidenavs, toolbars, menus',
       items: [
-        {id: 'menu', name: 'Menu', examples: ['menu-icons']},
+        {
+          id: 'menu',
+          name: 'Menu',
+          examples: [
+            'menu-overview',
+            'menu-icon',
+            'nested-menu'
+          ]
+        },
         {
           id: 'sidenav',
           name: 'Sidenav',


### PR DESCRIPTION
Includes all of the available menu examples under the menu "Examples" tab.