### PR TITLE
fix: menu icons example not rendering

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -112,7 +112,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
           name: 'Menu',
           examples: [
             'menu-overview',
-            'menu-icon',
+            'menu-icons',
             'nested-menu'
           ]
         },


### PR DESCRIPTION
Fixes one of the menu examples not rendering due to a typo.