### PR TITLE
fix: footer not sticking to bottom of the page on IE

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -106,14 +106,14 @@ app-component-sidenav {
 }
 
 .docs-component-sidenav-inner-content {
-  display: flex; 
+  display: flex;
   flex-direction: column;
   flex: 1;
 }
 
 .docs-component-sidenav-body-content {
   display: flex;
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 @media (max-width: $small-breakpoint-width) {


### PR DESCRIPTION
Fixes the body container collapsing on IE, causing the footer to show up right under the navigation.

For reference: 

![cdk__angular_material_-_internet_explorer_2018-05-16_22-55-10](https://user-images.githubusercontent.com/4450522/40143706-7131bb66-595c-11e8-8e7f-eb79a7b15f9e.png)
