### PR TITLE
feat: add ripples to documentation items

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -313,6 +313,12 @@ const DOCS: {[key: string]: DocCategory[]} = {
           summary: 'A linear progress indicator.',
           examples: ['progress-bar-configurable']
         },
+        {
+          id: 'ripple',
+          name: 'Ripples',
+          summary: 'Directive for adding Material Design ripple effects',
+          examples: ['ripple-overview']
+        }
       ]
     },
     {


### PR DESCRIPTION
* Adds the ripples to the documentation items 

  (Ripple examples depend on: https://github.com/angular/material2/commit/d7967765c2509160a260e741a1696c35df3bc35a)

---

**CARETAKER NOTE**: Merge **only** before a new **minor** version is being published (e.g. `6.5.0`).

cc. @mmalerba