### PR TITLE
build: ensure docs-content is up-to-date before deploy

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 declare -A PROJECT_ID
 
-#Firebase project Ids
+# Firebase project ids
 PROJECT_ID["stable", "dev"]="material2-docs-dev"
 PROJECT_ID["stable", "prod"]="material-angular-io"
 PROJECT_ID["v5", "dev"]="material2-docs-5"
@@ -14,7 +14,17 @@ version=${1:-stable}
 mode=${2:-dev}
 projectId=${PROJECT_ID[$version, $mode]}
 
+echo ""
+echo "NOTE: Make sure to refresh the docs-content to match the new version of docs."
+echo "      You can pull the docs-content for the new version by using the fetch-assets script."
+echo ""
+echo "      e.g. ./tools/fetch-assets.sh 6.4.x"
+echo ""
+
+read -p "Press <ENTER> to continue.."
+
 npm run build-themes
+
 $(npm bin)/ng build --aot --prod --build-optimizer=false
 $(npm bin)/firebase use $projectId
 $(npm bin)/firebase deploy

--- a/tools/fetch-assets.sh
+++ b/tools/fetch-assets.sh
@@ -6,6 +6,11 @@
 
 cd $(dirname ${0})/../
 
+# Branch on the docs-content repository that includes the docs assets. The branch can
+# be specified because in some situations we do not always want the docs-content of the
+# master branch (e.g. if `master` reflects the next major version).
+docsContentBranch=${1:-'master'}
+
 # Directory where documentation assets should be copied to (overviews, api docs)
 documentsDestination=./src/assets/documents/
 
@@ -33,8 +38,10 @@ mkdir -p ${materialExamplesDestination}
 # Remove previous repository if directory is present.
 rm -Rf ${docsContentPath}
 
+echo "Pulling docs-content assets for the branch: ${docsContentBranch}."
+
 # Clone the docs-content repository.
-git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1
+git clone ${docsContentRepoUrl} ${docsContentPath} --depth 1 --branch ${docsContentBranch}
 
 # Copy all document assets (API, overview and guides).
 cp -R ${docsContentPath}/api ${documentsDestination}


### PR DESCRIPTION
* Currently the `fetch-assets` script always fetches the data from the `master` branch. This is problematic because if we release a new patch release, we will incorrectly have the docs content for the upcoming major version. Adds the possibility to fetch the docs-content from a given branch (e.g. `6.4.x`)
* Adds a small note to the `deploy` script that makes the publisher aware of the docs-content, which should be kept updated.

This is related to https://github.com/angular/material2/pull/12690#event-1790790389