### PR TITLE
chore: expose all chips examples under examples tab

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -288,7 +288,12 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'chips',
           name: 'Chips',
           summary: 'Presents a list of items as a set of small, tactile entities.',
-          examples: ['chips-stacked']
+          examples: [
+            'chips-overview',
+            'chips-autocomplete',
+            'chips-input',
+            'chips-stacked',
+          ]
         },
         {
           id: 'icon',


### PR DESCRIPTION
Exposes all of the available chips examples under the "Examples" tab.