### PR TITLE
chore: remove web animation polyfill

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,9 +36,8 @@
   <script>
     // This hides the address bar on mobile browsers
     // https://developers.google.com/web/fundamentals/native-hardware/fullscreen/
-    window.addEventListener('load',function() { window.scrollTo(0, 1); });
+    window.addEventListener('load', function() { window.scrollTo(0, 1); });
   </script>
   <script src="https://ajax.googleapis.com/ajax/libs/hammerjs/2.0.8/hammer.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/web-animations/2.2.5/web-animations.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The WebAnimation polyfill hasn't been required since Angular 6.