### PR TITLE
Added dropdown icon to version picker

### DIFF
--- a/src/app/shared/version-picker/version-picker.html
+++ b/src/app/shared/version-picker/version-picker.html
@@ -1,5 +1,6 @@
 <button mat-button [matMenuTriggerFor]="versionPicker">
   {{materialVersion}}
+  <mat-icon>arrow_drop_down</mat-icon>
 </button>
 <mat-menu #versionPicker="matMenu">
   <button mat-menu-item *ngFor="let version of docVersions"

--- a/src/app/shared/version-picker/version-picker.ts
+++ b/src/app/shared/version-picker/version-picker.ts
@@ -1,6 +1,6 @@
 import {Component, NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {MatButtonModule, MatMenuModule} from '@angular/material';
+import {MatButtonModule, MatIconModule, MatMenuModule} from '@angular/material';
 import {docVersions, materialVersion, VersionInfo} from '../version/version';
 
 @Component({
@@ -22,7 +22,7 @@ export class VersionPicker {
 }
 
 @NgModule({
-  imports: [MatButtonModule, MatMenuModule, CommonModule],
+  imports: [MatButtonModule, MatIconModule, MatMenuModule, CommonModule],
   exports: [VersionPicker],
   declarations: [VersionPicker]
 })


### PR DESCRIPTION
A simple, but important change -

Added an arrow dropdown icon to the version picker. In my opinion, it is need immediately obvious that you can change versions. (I wasted a lot of time looking for the A5 website the other day). It doesn't really look interactive, it looks like it's just telling me the most recent version. 

A dropdown icon will make it more apparent that you can switch between A5 and A6 documentation. 

<img width="931" alt="screen shot 2018-09-24 at 12 58 57 am" src="https://user-images.githubusercontent.com/39655284/45938410-a4c2d900-bf97-11e8-8577-d4473d047094.png">
