### PR TITLE
chore: capitalization on nav item and enable commented out examples

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -397,11 +397,9 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'table-row-context',
             'table-selection',
             'table-sorting',
-
-            // Expose these examples with 6.3.0 release (sticky table)
-            // 'table-sticky-column',
-            // 'table-sticky-footer',
-            // 'table-sticky-header',
+            'table-sticky-column',
+            'table-sticky-footer',
+            'table-sticky-header',
         ]},
       ]
     }
@@ -468,7 +466,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
         },
         {
           id: 'drag-drop',
-          name: 'Drag and drop',
+          name: 'Drag and Drop',
           summary: 'Directives enabling drag-and-drop interactions',
           examples: [
             'cdk-drag-drop-axis-lock',


### PR DESCRIPTION
* Corrects the capitalization for the "Drag and Drop" menu item.
* Enables some examples that were waiting for the 6.3.0 release.