### PR TITLE
fix: table of contents not working within cdk

### DIFF
--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -30,12 +30,15 @@ export class MaterialDocsApp {
   }
 }
 
-function isNavigationWithinComponentView(oldUrl: string, newUrl: string) {
-  const componentViewExpression = /components\/(\w+)/;
-  return oldUrl && newUrl
-      && componentViewExpression.test(oldUrl)
-      && componentViewExpression.test(newUrl)
-      && oldUrl.match(componentViewExpression)[1] === newUrl.match(componentViewExpression)[1];
+function isNavigationWithinComponentView(previousUrl: string, newUrl: string) {
+  const componentViewExpression = /(cdk|components)\/(\w+)/;
+
+  const previousUrlMatch = previousUrl.match(componentViewExpression);
+  const newUrlMatch = newUrl.match(componentViewExpression);
+
+  return previousUrl && newUrl && previousUrlMatch && newUrlMatch
+      && previousUrlMatch[0] === newUrlMatch[0]
+      && previousUrlMatch[1] === newUrlMatch[1];
 }
 
 function resetScrollPosition() {


### PR DESCRIPTION
We intentionally reset the scroll position on navigation if the component view changed (e.g. if you switch from components/button to components/slider). Unfortunately this outdated check causes the CDK ToC to not work. This has been like that for V6 as well.

In order to make the ToC work for the CDK, we need to make sure that we don't reset the scroll position if someone navigates within a CDK doc entry.