### PR TITLE
fix(ci): hammerjs not loaded causes warnings and flaky failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@angular/platform-browser-dynamic": "^7.0.0",
     "@angular/router": "^7.0.0",
     "core-js": "^2.5.6",
+    "hammerjs": "^2.0.8",
     "moment": "^2.22.1",
     "rxjs": "^6.1.0",
     "zone.js": "^0.8.26"
@@ -44,7 +45,6 @@
     "@types/jasmine": "^2.8.9",
     "@types/node": "^10.0.9",
     "firebase-tools": "^3.15.3",
-    "hammerjs": "^2.0.8",
     "highlight.js": "^9.9.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",

--- a/src/app/app-module.ts
+++ b/src/app/app-module.ts
@@ -8,25 +8,25 @@ import {MatNativeDateModule} from '@angular/material';
 import {ExampleModule} from '@angular/material-examples';
 
 import {MaterialDocsApp} from './material-docs-app';
-import {HomepageModule} from './pages/homepage/homepage';
+import {HomepageModule} from './pages/homepage';
 import {MATERIAL_DOCS_ROUTES} from './routes';
-import {ComponentListModule} from './pages/component-list/component-list';
+import {ComponentListModule} from './pages/component-list';
 import {ComponentViewerModule} from './pages/component-viewer/component-viewer';
 import {ComponentCategoryListModule} from './pages/component-category-list/component-category-list';
 import {ComponentSidenavModule} from './pages/component-sidenav/component-sidenav';
 import {FooterModule} from './shared/footer/footer';
 import {ComponentPageTitle} from './pages/page-title/page-title';
 import {ComponentHeaderModule} from './pages/component-page-header/component-page-header';
-import {StyleManager} from './shared/style-manager/style-manager';
+import {StyleManager} from './shared/style-manager';
 import {SvgViewerModule} from './shared/svg-viewer/svg-viewer';
-import {ThemePickerModule} from './shared/theme-picker/theme-picker';
-import {StackblitzButtonModule} from './shared/stackblitz/stackblitz-button';
-import {NavBarModule} from './shared/navbar/navbar';
+import {ThemePickerModule} from './shared/theme-picker';
+import {StackblitzButtonModule} from './shared/stackblitz';
+import {NavBarModule} from './shared/navbar';
 import {ThemeStorage} from './shared/theme-picker/theme-storage/theme-storage';
 import {GuideItems} from './shared/guide-items/guide-items';
 import {DocumentationItems} from './shared/documentation-items/documentation-items';
-import {GuideListModule} from './pages/guide-list/guide-list';
-import {GuideViewerModule} from './pages/guide-viewer/guide-viewer';
+import {GuideListModule} from './pages/guide-list';
+import {GuideViewerModule} from './pages/guide-viewer';
 import {DocViewerModule} from './shared/doc-viewer/doc-viewer-module';
 import {
   CanActivateComponentSidenav

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,6 +6,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
+import 'hammerjs';
 
 declare const require: any;
 


### PR DESCRIPTION
import hammerjs for the tests
shorten a few imports


I didn't import hammerjs in `main.ts` since that isn't needed to fix the tests, but it does seem like it should be there. Was there a reason to avoid enabling it on the docs site? Should I add it in?