### PR TITLE
feat: add the ability to link to the site with a particular theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,13 +5990,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6019,7 +6021,8 @@
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6186,6 +6189,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8699,7 +8703,7 @@
     "jsonschema": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha1-g6ucY9Zb9NWW+R2BGV54dy9kUrw=",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -9736,7 +9740,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -10745,7 +10749,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/app/shared/theme-picker/theme-picker.html
+++ b/src/app/shared/theme-picker/theme-picker.html
@@ -7,7 +7,7 @@
 <mat-menu class="docs-theme-picker-menu" #themeMenu="matMenu" x-position="before">
   <mat-grid-list cols="2">
     <mat-grid-tile *ngFor="let theme of themes">
-      <div mat-menu-item (click)="installTheme(theme)">
+      <div mat-menu-item (click)="installTheme(theme.name)">
         <div class="docs-theme-picker-swatch">
           <mat-icon class="docs-theme-chosen-icon" *ngIf="currentTheme === theme">check_circle</mat-icon>
           <div class="docs-theme-picker-primary" [style.background]="theme.primary"></div>

--- a/src/app/shared/theme-picker/theme-picker.spec.ts
+++ b/src/app/shared/theme-picker/theme-picker.spec.ts
@@ -10,17 +10,13 @@ describe('ThemePicker', () => {
     }).compileComponents();
   }));
 
-  it('should install theme based on href', () => {
+  it('should install theme based on name', () => {
     const fixture = TestBed.createComponent(ThemePicker);
     const component = fixture.componentInstance;
-    const href = 'pink-bluegrey.css';
+    const name = 'pink-bluegrey';
     spyOn(component.styleManager, 'setStyle');
-    component.installTheme({
-      primary: '#E91E63',
-      accent: '#607D8B',
-      href,
-    });
+    component.installTheme(name);
     expect(component.styleManager.setStyle).toHaveBeenCalled();
-    expect(component.styleManager.setStyle).toHaveBeenCalledWith('theme', `assets/${href}`);
+    expect(component.styleManager.setStyle).toHaveBeenCalledWith('theme', `assets/${name}.css`);
   });
 });

--- a/src/app/shared/theme-picker/theme-storage/theme-storage.spec.ts
+++ b/src/app/shared/theme-picker/theme-storage/theme-storage.spec.ts
@@ -1,40 +1,39 @@
-import {ThemeStorage} from './theme-storage';
+import {ThemeStorage, DocsSiteTheme} from './theme-storage';
 
 
 const testStorageKey = ThemeStorage.storageKey;
-const testTheme = {
+const testTheme: DocsSiteTheme = {
   primary: '#000000',
   accent: '#ffffff',
-  href: 'test/path/to/theme'
-};
-const createTestData = () => {
-  window.localStorage[testStorageKey] = JSON.stringify(testTheme);
-};
-const clearTestData = () => {
-  window.localStorage.clear();
+  name: 'test-theme'
 };
 
 describe('ThemeStorage Service', () => {
   const service = new ThemeStorage();
-  const getCurrTheme = () => JSON.parse(window.localStorage.getItem(testStorageKey));
+  const getCurrTheme = () => window.localStorage.getItem(testStorageKey);
   const secondTestTheme = {
     primary: '#666666',
     accent: '#333333',
-    href: 'some/cool/path'
+    name: 'other-test-theme'
   };
 
-  beforeEach(createTestData);
-  afterEach(clearTestData);
-
-  it('should set the current theme', () => {
-    expect(getCurrTheme()).toEqual(testTheme);
-    service.storeTheme(secondTestTheme);
-    expect(getCurrTheme()).toEqual(secondTestTheme);
+  beforeEach(() => {
+    window.localStorage[testStorageKey] = testTheme.name;
   });
 
-  it('should get the current theme', () => {
-    const theme = service.getStoredTheme();
-    expect(theme).toEqual(testTheme);
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('should set the current theme name', () => {
+    expect(getCurrTheme()).toEqual(testTheme.name);
+    service.storeTheme(secondTestTheme);
+    expect(getCurrTheme()).toEqual(secondTestTheme.name);
+  });
+
+  it('should get the current theme name', () => {
+    const theme = service.getStoredThemeName();
+    expect(theme).toEqual(testTheme.name);
   });
 
   it('should clear the stored theme data', () => {

--- a/src/app/shared/theme-picker/theme-storage/theme-storage.ts
+++ b/src/app/shared/theme-picker/theme-storage/theme-storage.ts
@@ -1,7 +1,7 @@
 import {Injectable, EventEmitter} from '@angular/core';
 
 export interface DocsSiteTheme {
-  href: string;
+  name: string;
   accent: string;
   primary: string;
   isDark?: boolean;
@@ -11,22 +11,22 @@ export interface DocsSiteTheme {
 
 @Injectable()
 export class ThemeStorage {
-  static storageKey = 'docs-theme-storage-current';
+  static storageKey = 'docs-theme-storage-current-name';
 
   onThemeUpdate: EventEmitter<DocsSiteTheme> = new EventEmitter<DocsSiteTheme>();
 
   storeTheme(theme: DocsSiteTheme) {
     try {
-      window.localStorage[ThemeStorage.storageKey] = JSON.stringify(theme);
-    } catch (e) { }
+      window.localStorage[ThemeStorage.storageKey] = theme.name;
+    } catch { }
 
     this.onThemeUpdate.emit(theme);
   }
 
-  getStoredTheme(): DocsSiteTheme {
+  getStoredThemeName(): string | null {
     try {
-      return JSON.parse(window.localStorage[ThemeStorage.storageKey] || null);
-    } catch (e) {
+      return window.localStorage[ThemeStorage.storageKey] || null;
+    } catch {
       return null;
     }
   }
@@ -34,6 +34,6 @@ export class ThemeStorage {
   clearStorage() {
     try {
       window.localStorage.removeItem(ThemeStorage.storageKey);
-    } catch (e) { }
+    } catch { }
   }
 }


### PR DESCRIPTION
* Reworks the theming setup to store only the current theme's name, rather than the entire object in `localStorage`. This is more robust for the cases where we want to change the theme object's interface.
* Adds the ability to link people to the docs site with a particular theme (e.g. https://material.angular.io?theme=purple-green). This allows us to preview the theme. For example we can use it for https://github.com/angular/material2/issues/13708 to show people what the theme would look like when they're prompted in a schematic.