### PR TITLE
fix: sticky table example not loading

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -397,7 +397,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'table-row-context',
             'table-selection',
             'table-sorting',
-            'table-sticky-column',
+            'table-sticky-columns',
             'table-sticky-footer',
             'table-sticky-header',
         ]},
@@ -459,7 +459,9 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'platform',
           name: 'Platform',
           summary: 'Provides information about the user\'s platform.',
-          examples: []
+          examples: [
+            'cdk-platform-overview',
+          ]
         },
         {
           id: 'portal',


### PR DESCRIPTION
* Fixes that the sticky table examples does not load (see: angular/material2#13872)
* Adds the new cdk platform overview example to the `Examples` section as well.

Closes angular/material2#13872.