### PR TITLE
chore: update StackBlitz examples to use Angular v7

### DIFF
--- a/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -23,7 +23,7 @@ const TEMPLATE_FILES = [
 ];
 
 const TAGS: string[] = ['angular', 'material', 'example'];
-const angularVersion = '>=6.0.0-beta.0 <7.0.0';
+const angularVersion = '>=7.0.0';
 
 const dependencies = {
   '@angular/cdk': materialVersion,


### PR DESCRIPTION
Closes angular/material2#13975