### PR TITLE
build: fix unit test after example-module refactor

### DIFF
--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -97,8 +97,8 @@ describe('ExampleViewer', () => {
 
     it('should be able to render additional files', () => {
       EXAMPLE_COMPONENTS['additional-files'] = {
+        ...EXAMPLE_COMPONENTS[exampleKey],
         additionalFiles: ['some-additional-file.html'],
-        ...EXAMPLE_COMPONENTS[exampleKey]
       };
 
       component.example = 'additional-files';


### PR DESCRIPTION
Our test data is overwritten by `Object.assign` because the `example-module` now always has `additionalFiles` set to an empty array.