### PR TITLE
chore: include form field appearance example

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -92,6 +92,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
           examples: [
             'form-field-overview',
             'form-field-label',
+            'form-field-appearance',
             'form-field-hint',
             'form-field-error',
             'form-field-prefix-suffix',


### PR DESCRIPTION
Includes the appearance example in the list of examples for the form field.

Relates to https://github.com/angular/material2/issues/14400.