### PR TITLE
build: add preinstall script to check for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "postinstall": "webdriver-manager update && bash ./tools/build-themes.sh",
     "publish-prod": "bash ./tools/deploy.sh stable prod",
     "publish-dev": "bash ./tools/deploy.sh",
-    "publish-beta": "bash ./tools/deploy.sh stable beta"
+    "publish-beta": "bash ./tools/deploy.sh stable beta",
+    "preinstall": "node ./tools/check-npm.js"
   },
   "private": true,
   "dependencies": {

--- a/tools/check-npm.js
+++ b/tools/check-npm.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+if (process.env.npm_execpath.indexOf('yarn') === -1) {
+  console.error('Please use Yarn instead of NPM to install dependencies. ' +
+                'See: https://yarnpkg.com/lang/en/docs/install/');
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a script to prevent people from accidentally running `npm i`, similarly to the angular/material2 and angular/angular repos.