### PR TITLE
fix: correct paths to icons in application manifest

### DIFF
--- a/src/assets/img/favicons/manifest.json
+++ b/src/assets/img/favicons/manifest.json
@@ -8,37 +8,37 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "\/android-chrome-36x36.png",
+      "src": "\/assets/img/favicons/android-chrome-36x36.png",
       "sizes": "36x36",
       "type": "image\/png",
       "density": "0.75"
     },
     {
-      "src": "\/android-chrome-48x48.png",
+      "src": "\/assets/img/favicons/android-chrome-48x48.png",
       "sizes": "48x48",
       "type": "image\/png",
       "density": "1.0"
     },
     {
-      "src": "\/android-chrome-72x72.png",
+      "src": "\/assets/img/favicons/android-chrome-72x72.png",
       "sizes": "72x72",
       "type": "image\/png",
       "density": "1.5"
     },
     {
-      "src": "\/android-chrome-96x96.png",
+      "src": "\/assets/img/favicons/android-chrome-96x96.png",
       "sizes": "96x96",
       "type": "image\/png",
       "density": "2.0"
     },
     {
-      "src": "\/android-chrome-144x144.png",
+      "src": "\/assets/img/favicons/android-chrome-144x144.png",
       "sizes": "144x144",
       "type": "image\/png",
       "density": "3.0"
     },
     {
-      "src": "\/android-chrome-192x192.png",
+      "src": "\/assets/img/favicons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image\/png",
       "density": "4.0"


### PR DESCRIPTION
Minor change.
This removes the fetch errors for resources described in the application
manifest file.
For example, the full path of related resourse is:

https://material.angular.io/assets/img/favicons/android-chrome-36x36.png

Thanks!