### PR TITLE
fix: missing import for a11y module

### DIFF
--- a/src/assets/stackblitz/material-module.ts
+++ b/src/assets/stackblitz/material-module.ts
@@ -2,6 +2,7 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {CdkTableModule} from '@angular/cdk/table';
 import {CdkTreeModule} from '@angular/cdk/tree';
+import {A11yModule} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
 import {
   MatAutocompleteModule,
@@ -43,6 +44,7 @@ import {
 
 @NgModule({
   exports: [
+    A11yModule,
     CdkTableModule,
     CdkTreeModule,
     DragDropModule,


### PR DESCRIPTION
There are some examples that depend on the `A11yModule` and they break if they're forked into a Stackblitz, because we don't import the `A11yModule` directly anywhere.

Fixes https://github.com/angular/material2/issues/14761