### PR TITLE
fix: missing import for `PortalModule`

### DIFF
--- a/src/assets/stackblitz/material-module.ts
+++ b/src/assets/stackblitz/material-module.ts
@@ -1,5 +1,6 @@
 import {A11yModule} from '@angular/cdk/a11y';
 import {DragDropModule} from '@angular/cdk/drag-drop';
+import {PortalModule} from '@angular/cdk/portal';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {CdkStepperModule} from '@angular/cdk/stepper';
 import {CdkTableModule} from '@angular/cdk/table';
@@ -85,6 +86,7 @@ import {
     MatToolbarModule,
     MatTooltipModule,
     MatTreeModule,
+    PortalModule,
     ScrollingModule,
   ]
 })


### PR DESCRIPTION
There are some examples that depend on the `PortalModule` and they break
if they're forked into a Stackblitz, because we don't import the `PortalModule`
directly anywhere.

Fixes https://github.com/angular/material2/issues/15175