### PR TITLE
chore: run explicit static-query timing migration

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -34,7 +34,7 @@ export class ComponentSidenav implements OnInit {
         .pipe(map(breakpoint => breakpoint.matches));
   }
 
-  @ViewChild(MatSidenav, { static: false }) sidenav: MatSidenav;
+  @ViewChild(MatSidenav, {static: false}) sidenav: MatSidenav;
 
   ngOnInit() {
     // Combine params from all of the path into a single object.

--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -34,7 +34,7 @@ export class ComponentSidenav implements OnInit {
         .pipe(map(breakpoint => breakpoint.matches));
   }
 
-  @ViewChild(MatSidenav) sidenav: MatSidenav;
+  @ViewChild(MatSidenav, { static: false }) sidenav: MatSidenav;
 
   ngOnInit() {
     // Combine params from all of the path into a single object.

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -65,8 +65,8 @@ export class ComponentViewer implements OnDestroy {
   encapsulation: ViewEncapsulation.None,
 })
 export class ComponentOverview implements OnInit {
-  @ViewChild('initialFocusTarget', { static: false }) focusTarget: ElementRef;
-  @ViewChild('toc', { static: false }) tableOfContents: TableOfContents;
+  @ViewChild('initialFocusTarget', {static: false}) focusTarget: ElementRef;
+  @ViewChild('toc', {static: false}) tableOfContents: TableOfContents;
   showToc: Observable<boolean>;
 
   constructor(public componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -65,8 +65,8 @@ export class ComponentViewer implements OnDestroy {
   encapsulation: ViewEncapsulation.None,
 })
 export class ComponentOverview implements OnInit {
-  @ViewChild('initialFocusTarget') focusTarget: ElementRef;
-  @ViewChild('toc') tableOfContents: TableOfContents;
+  @ViewChild('initialFocusTarget', { static: false }) focusTarget: ElementRef;
+  @ViewChild('toc', { static: false }) tableOfContents: TableOfContents;
   showToc: Observable<boolean>;
 
   constructor(public componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {


### PR DESCRIPTION
This is the result of the static-query ng-update schematic. Mostly ran it for testing, but should be good to keep if we update the app to V8-beta.