### PR TITLE
chore: link to full license from footer

### DIFF
--- a/src/app/shared/footer/footer.html
+++ b/src/app/shared/footer/footer.html
@@ -16,7 +16,7 @@
 
     <div class="docs-footer-copyright">
       <span>Powered by Google ©2010-2019.</span>
-      <span>Code licensed under an MIT-style License.</span>
+      <a href="https://github.com/angular/components/blob/master/LICENSE">Code licensed under an MIT-style License.</a>
       <span>Documentation licensed under CC BY 4.0.</span>
     </div>
   </div>

--- a/src/app/shared/footer/footer.scss
+++ b/src/app/shared/footer/footer.scss
@@ -42,12 +42,15 @@
   a {
     font-size: 16px;
     padding: 0;
-    text-decoration: none;
-    color: inherit;
+  }
+}
 
-    &:hover {
-      text-decoration: underline;
-    }
+a {
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
Links to the full license from the footer, similar to angular.io. Note that it links to the repo since we don't have a dedicated license page.

Fixes https://github.com/angular/components/issues/16039.