### PR TITLE
feat(license): add license component to display full license

### DIFF
--- a/src/app/pages/homepage/homepage.ts
+++ b/src/app/pages/homepage/homepage.ts
@@ -4,6 +4,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {FooterModule} from '../../shared/footer/footer';
 import {RouterModule} from '@angular/router';
 import {ComponentPageTitle} from '../page-title/page-title';
+import { LicenseModule } from '../license/license';
 
 @Component({
   selector: 'app-homepage',
@@ -21,7 +22,7 @@ export class Homepage implements OnInit {
 }
 
 @NgModule({
-  imports: [SvgViewerModule, MatButtonModule, FooterModule, RouterModule],
+  imports: [SvgViewerModule, MatButtonModule, FooterModule, RouterModule, LicenseModule],
   exports: [Homepage],
   declarations: [Homepage],
 })

--- a/src/app/pages/license/license.html
+++ b/src/app/pages/license/license.html
@@ -1,0 +1,21 @@
+<div class="license-content">
+    <p class="license-title">The MIT License</p>
+    <p>Copyright (c) 2010-2019 Google LLC. <a href="license">http://material.angular.io/license</a></p>
+    <p>Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:</p>
+    <p>The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.</p>
+    <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.</p>
+</div>
+
+<app-footer></app-footer>

--- a/src/app/pages/license/license.scss
+++ b/src/app/pages/license/license.scss
@@ -1,0 +1,16 @@
+@import '../../../styles/constants';
+
+:host {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+.license-content {
+    flex-grow: 1;
+    margin: $content-padding-side;
+  
+    @media (max-width: $small-breakpoint-width) {
+      margin: 0;
+    }
+}

--- a/src/app/pages/license/license.ts
+++ b/src/app/pages/license/license.ts
@@ -1,0 +1,16 @@
+import { Component, NgModule } from "@angular/core";
+import { FooterModule } from "../../shared/footer/footer";
+
+@Component({
+    selector: 'app-license',
+    templateUrl: './license.html',
+    styleUrls: ['./license.scss']
+})
+export class License {}
+
+@NgModule({
+    imports: [FooterModule],
+    exports: [License],
+    declarations: [License],
+})
+export class LicenseModule {}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -14,10 +14,12 @@ import {
   CanActivateComponentSidenav
 } from './pages/component-sidenav/component-sidenav-can-load-guard';
 import {GuideViewer} from './pages/guide-viewer/guide-viewer';
+import {License} from './pages/license/license';
 
 export const MATERIAL_DOCS_ROUTES: Routes = [
   {path: '', component: Homepage, pathMatch: 'full', data: {}},
   {path: 'categories', redirectTo: '/components/categories'},
+  {path: 'license', component: License},
   {path: 'guides', component: GuideList, data: {}},
   // Since https://github.com/angular/components/pull/9574, the cdk-table guide became the overview
   // document for the cdk table. To avoid any dead / broken links, we redirect to the new location.

--- a/src/app/shared/footer/footer.html
+++ b/src/app/shared/footer/footer.html
@@ -16,7 +16,7 @@
 
     <div class="docs-footer-copyright">
       <span>Powered by Google ©2010-2019.</span>
-      <span>Code licensed under an MIT-style License.</span>
+      <span>Code licensed under an <a [routerLink]="['/license']" title="License text">MIT-style License</a>.</span>
       <span>Documentation licensed under CC BY 4.0.</span>
     </div>
   </div>

--- a/src/app/shared/footer/footer.scss
+++ b/src/app/shared/footer/footer.scss
@@ -31,6 +31,10 @@
   flex-direction: column;
   min-width: 225px;
   text-align: center;
+
+  a:any-link {
+    color: inherit;
+  }
 }
 
 .docs-footer-logo span {

--- a/src/app/shared/footer/footer.ts
+++ b/src/app/shared/footer/footer.ts
@@ -1,5 +1,7 @@
 import {Component, NgModule} from '@angular/core';
 import {materialVersion} from '../version/version';
+import { RouterModule } from '@angular/router';
+import { MATERIAL_DOCS_ROUTES } from '../../routes';
 
 @Component({
   selector: 'app-footer',
@@ -14,6 +16,7 @@ export class Footer {
 
 
 @NgModule({
+  imports: [RouterModule.forRoot(MATERIAL_DOCS_ROUTES)],
   exports: [Footer],
   declarations: [Footer],
 })


### PR DESCRIPTION
Adding the full license aggreement as per angular.io example in reference to angular/components#16039