### PR TITLE
fix(manifest.json): use rel paths, remove density

### DIFF
--- a/src/assets/img/favicons/manifest.json
+++ b/src/assets/img/favicons/manifest.json
@@ -8,40 +8,34 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "\/android-chrome-36x36.png",
+      "src": "./android-chrome-36x36.png",
       "sizes": "36x36",
-      "type": "image\/png",
-      "density": "0.75"
+      "type": "image/png"
     },
     {
-      "src": "\/android-chrome-48x48.png",
+      "src": "./android-chrome-48x48.png",
       "sizes": "48x48",
-      "type": "image\/png",
-      "density": "1.0"
+      "type": "image/png"
     },
     {
-      "src": "\/android-chrome-72x72.png",
+      "src": "./android-chrome-72x72.png",
       "sizes": "72x72",
-      "type": "image\/png",
-      "density": "1.5"
+      "type": "image/png"
     },
     {
-      "src": "\/android-chrome-96x96.png",
+      "src": "./android-chrome-96x96.png",
       "sizes": "96x96",
-      "type": "image\/png",
-      "density": "2.0"
+      "type": "image/png"
     },
     {
-      "src": "\/android-chrome-144x144.png",
+      "src": "./android-chrome-144x144.png",
       "sizes": "144x144",
-      "type": "image\/png",
-      "density": "3.0"
+      "type": "image/png"
     },
     {
-      "src": "\/android-chrome-192x192.png",
+      "src": "./android-chrome-192x192.png",
       "sizes": "192x192",
-      "type": "image\/png",
-      "density": "4.0"
+      "type": "image/png"
     }
   ]
 }


### PR DESCRIPTION
fixes #599
 
The paths are broken and the escapes "\" are unnecessary. Also, there is no longer `density` member in the spec. It was removed a few years ago.