### PR TITLE
chore: set display when loading fonts

### DIFF
--- a/src/assets/stackblitz/index.html
+++ b/src/assets/stackblitz/index.html
@@ -1,4 +1,4 @@
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet">
 <div class="mat-app-background basic-container">
   <material-docs-example>loading</material-docs-example>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,8 @@
   <link rel="icon" type="image/png" href="assets/img/favicons/android-chrome-192x192.png"
       sizes="192x192">
   <link rel="manifest" href="assets/img/favicons/manifest.json">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300&display=swap" rel="stylesheet">
 </head>
 
 <body class="docs-app-background">


### PR DESCRIPTION
Along the same lines as https://github.com/angular/components/pull/16093. Sets the `display` parameter when loading fonts for better control over how they're loaded.