### PR TITLE
docs(readme): update and corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,61 @@
-# Angular Material Docs Site
+# Angular Components Docs Site
 
-This is the repository for the [Angular Material documentation site](https://material.angular.io/).
+This is the repository for the [Angular Components documentation site](https://material.angular.io/).
 
 Versions of this site are also available for
 - [Beta](https://next.material.angular.io/)
 - [v5](https://v5.material.angular.io/)
 - [v6](https://v6.material.angular.io/)
 - [v7](https://v7.material.angular.io/)
+- [v8](https://material.angular.io/)
 
 ## Contributing
-Please open bugs against the Angular Material components, directives, documentation contents, API docs,
-and demos in the [Angular Material repo](https://github.com/angular/components/issues).
+Please open bugs against the Angular Material and CDK components, directives, documentation
+contents, API docs, and demos in the
+[Angular Components repo](https://github.com/angular/components/issues).
 
 Please only open issues with the documentation site itself (not the content) in
-[this repo](https://github.com/angular/material.angular.io/issues). This includes issues like the navigation
-not working properly, examples or documentation not being presented in an accessible way, issues with
-rendering or layout of the documentation pages, etc.
+[this repo](https://github.com/angular/material.angular.io/issues). This includes issues like the
+navigation not working properly, examples or documentation not being presented in an accessible way,
+issues with rendering or layout of the documentation pages, etc.
 
 ### Where does the content come from?
-The documentation is generated from the following resources
-- [Guides](https://github.com/angular/components/tree/master/guides)
-- [Examples](https://github.com/angular/components/tree/master/src/material-examples)
+The guides, examples, and docs content repo
+[angular/material2-docs-content](https://github.com/angular/material2-docs-content) contains the
+documentation content and examples. They are generated from:
+- [Angular Material and CDK Guides](https://github.com/angular/components/tree/master/guides)
 - [Material components, services, and directives](https://github.com/angular/components/tree/master/src/lib)
 - [CDK components, services, and directives](https://github.com/angular/components/tree/master/src/cdk)
 
 ## Development Setup
-1. Clone Angular Material in the parent directory of this repo
-    1. `cd ..`
-    1. `git clone git@github.com:angular/components.git`
-1. Install Gulp globally: `npm i -g gulp`
-1. Build and copy docs and examples from Angular Material: `npm run fetch-local`
-    - Note that you may need to run this after each time that you run `npm i` as some of the examples are
-      actually placed in `node_modules/@angular/`
-    - If you see the error `Cannot find module '@angular/material-examples'`,
-      it means that you need to run `npm run fetch-local` again
+1. Make sure that you have [NodeJS LTS](https://nodejs.org) installed
+1. Make sure that you have [Yarn](https://yarnpkg.com) installed
+1. Install the project's dependencies
+  - `yarn install`
+1. Update to the latest version of the docs-content and examples
+  - `yarn upgrade @angular/material-examples`
 
 ## Development Server
-1. Run `npm start` for a dev server. Navigate to `http://localhost:4200/`
+1. Run `yarn start` for a dev server. Navigate to `http://localhost:4200/`
 
 ## Build
-Run `npm run prod-build` to build the project.
+Run `yarn prod-build` to build the project.
 
 ## Running unit tests
-1. Run `npm run test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+1. Run `yarn test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
 ## Running end-to-end tests
-Run `npm run e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
-Before running the tests make sure you are serving the app via `npm start`.
+Run `yarn e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
+Before running the tests make sure you are serving the app via `yarn start`.
 
 ## Deployment instructions
 ```
-> npm install
+> yarn install
+> yarn upgrade @angular/material-examples
 
 # Development
-> npm run publish-dev
+> yarn publish-dev
 
 # Production
-> npm run publish-prod
+> yarn publish-prod
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "e2e": "protractor",
     "build-themes": "bash ./tools/build-themes.sh",
     "prod-build": "npm run build-themes && ng build --aot --prod",
-    "postinstall": "webdriver-manager update --gecko false && bash ./tools/build-themes.sh",
+    "postinstall": "webdriver-manager update --gecko false && npm run build-themes",
     "publish-prod": "bash ./tools/deploy.sh stable prod",
     "publish-dev": "bash ./tools/deploy.sh",
     "publish-beta": "bash ./tools/deploy.sh stable beta"

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,8 +196,8 @@
     tslib "^1.9.0"
 
 "@angular/material-examples@angular/material2-docs-content#master":
-  version "8.0.0-rc.1-b66a9a2"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/4a5091c133bdf458173e9b40ae0fe3cbe14cbb04"
+  version "8.1.2-6416bab"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/5f2d9e24e27a8d5bd99469ad59ab9968c070f378"
   dependencies:
     tslib "^1.7.1"
 
@@ -8874,7 +8874,12 @@ ts-node@^6.0.3:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
- npm -> yarn
- more updates from Angular Material -> Angular Components
- add details on material2-docs-content repo
- correct development setup steps
- update to latest material2-docs-content
- postinstall task uses build-themes task

Fixes #578. Closes #583.

