### PR TITLE
fix(a11y): various issues with contrast ratios

### DIFF
--- a/src/app/pages/component-sidenav/_component-sidenav-theme.scss
+++ b/src/app/pages/component-sidenav/_component-sidenav-theme.scss
@@ -35,7 +35,7 @@
 
       &.docs-component-viewer-sidenav-item-selected,
       &:hover {
-        color: mat-color($primary);
+        color: mat-color($primary, if($is-dark-theme, 200, default));
       }
     }
   }

--- a/src/app/pages/guide-list/_guide-list-theme.scss
+++ b/src/app/pages/guide-list/_guide-list-theme.scss
@@ -6,8 +6,9 @@
   $warn: map-get($theme, warn);
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
+  $is-dark-theme: map-get($theme, is-dark);
 
   .docs-guide-list .docs-guide-item {
-    color: mat-color($primary);
+    color: mat-color($primary, if($is-dark-theme, 200, default));
   }
 }

--- a/src/app/shared/table-of-contents/_table-of-contents-theme.scss
+++ b/src/app/shared/table-of-contents/_table-of-contents-theme.scss
@@ -4,6 +4,7 @@
   $warn: map-get($theme, warn);
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
+  $is-dark-theme: map-get($theme, is-dark);
 
   .docs-toc-container {
     border-left: solid 4px mat-color($primary);
@@ -14,7 +15,7 @@
 
       &:hover,
       &.docs-active {
-        color: mat-color($primary);
+        color: mat-color($primary, if($is-dark-theme, 200, default));
       }
     }
   }

--- a/src/highlightjs/material-dark.scss
+++ b/src/highlightjs/material-dark.scss
@@ -18,7 +18,7 @@ Orginal Style from https://github.com/Kelbster/highlightjs-material-dark-theme  
 }
 
 .hljs-comment {
-  color: #656565;
+  color: #9E9E9E;
   font-style: italic;
 }
 

--- a/src/highlightjs/material-light.scss
+++ b/src/highlightjs/material-light.scss
@@ -17,7 +17,7 @@
 }
 
 .hljs-comment {
-  color: #B0BEC5;
+  color: #616161;
   font-style: italic;
 }
 

--- a/src/styles/_api-theme.scss
+++ b/src/styles/_api-theme.scss
@@ -9,9 +9,24 @@
   $foreground: map-get($theme, foreground);
   $is-dark-theme: map-get($theme, is-dark);
 
-  .docs-api-method-returns-type,
-  .docs-api-method-parameter-type {
-    color: mat-color($primary, darker);
+  @if $is-dark-theme {
+    .docs-api-method-name-cell {
+      color: mat-color($primary, 200);
+    }
+
+    .docs-api-method-returns-type,
+    .docs-api-method-parameter-type {
+      color: mat-color($primary, 200);
+    }
+  } @else {
+    .docs-api-method-name-cell {
+      color: mat-color($primary, 800);
+    }
+
+    .docs-api-method-returns-type,
+    .docs-api-method-parameter-type {
+      color: mat-color($primary, darker);
+    }
   }
 
   // Force the top-level API docs header to be hidden, since this is already

--- a/src/styles/_markdown-theme.scss
+++ b/src/styles/_markdown-theme.scss
@@ -12,7 +12,7 @@
 
   .docs-markdown {
     a {
-      color: mat-color($primary);
+      color: mat-color($primary, if($is-dark-theme, 200, default));
     }
 
     pre {


### PR DESCRIPTION
All contrast ratios are now above `4.5`.

# Before then After

![Screen Shot 2019-09-19 at 23 28 31](https://user-images.githubusercontent.com/3506071/65297341-7c7fa300-db35-11e9-9ea4-b8f7124a0105.png)
![Screen Shot 2019-09-19 at 23 28 12](https://user-images.githubusercontent.com/3506071/65297342-7d183980-db35-11e9-919a-3f612a18d610.png)

![Screen Shot 2019-09-19 at 22 42 57](https://user-images.githubusercontent.com/3506071/65297344-7d183980-db35-11e9-8194-5bcde66941b9.png)
![Screen Shot 2019-09-19 at 22 43 07](https://user-images.githubusercontent.com/3506071/65297343-7d183980-db35-11e9-9570-58a5a0dcdec2.png)

![Screen Shot 2019-09-19 at 22 40 53](https://user-images.githubusercontent.com/3506071/65297345-7d183980-db35-11e9-9048-6734997a60f0.png)
![Screen Shot 2019-09-19 at 22 40 42](https://user-images.githubusercontent.com/3506071/65297346-7d183980-db35-11e9-834d-11c0afc4e20c.png)

![Screen Shot 2019-09-19 at 22 38 55](https://user-images.githubusercontent.com/3506071/65297347-7d183980-db35-11e9-8b81-012b83834ffa.png)
![Screen Shot 2019-09-19 at 22 38 34](https://user-images.githubusercontent.com/3506071/65297348-7d183980-db35-11e9-9184-f4a9ea583520.png)

![Screen Shot 2019-09-19 at 22 33 55](https://user-images.githubusercontent.com/3506071/65297349-7d183980-db35-11e9-8a4a-229e68a0cc23.png)
![Screen Shot 2019-09-19 at 22 33 41](https://user-images.githubusercontent.com/3506071/65297350-7d183980-db35-11e9-9f01-da6d18324038.png)

![Screen Shot 2019-09-19 at 22 20 47](https://user-images.githubusercontent.com/3506071/65297352-7db0d000-db35-11e9-90f4-cea9f4a7e039.png)
![Screen Shot 2019-09-19 at 22 20 57](https://user-images.githubusercontent.com/3506071/65297351-7db0d000-db35-11e9-8eda-6435b8662ef2.png)

Fixes #398. Reverts #399.

I also ran into https://github.com/angular/components/issues/17152, but that example needs to be fixed in the Components repo.