### PR TITLE
fix(a11y): improve contrast of accent in pink-bluegrey theme

### DIFF
--- a/src/assets/custom-themes/pink-bluegrey.scss
+++ b/src/assets/custom-themes/pink-bluegrey.scss
@@ -3,7 +3,7 @@
 
 // Define the dark theme.
 $primary: mat-palette($mat-pink);
-$accent:  mat-palette($mat-blue-grey, A200, A100, A400);
+$accent:  mat-palette($mat-blue-grey);
 
 $theme: mat-dark-theme($primary, $accent);
 @include angular-material-theme($theme);


### PR DESCRIPTION
Fixes #222

### First unselected/unchecked, then Before, then After
![Screen Shot 2019-09-20 at 00 08 02](https://user-images.githubusercontent.com/3506071/65298828-ef3f4d00-db3a-11e9-92a0-81b8fe5b680d.png)
![Screen Shot 2019-09-20 at 00 08 08](https://user-images.githubusercontent.com/3506071/65298827-ef3f4d00-db3a-11e9-8114-b3310b2dfd9b.png)
![Screen Shot 2019-09-20 at 00 08 15](https://user-images.githubusercontent.com/3506071/65298826-ef3f4d00-db3a-11e9-930b-f1be2e503cdf.png)

![Screen Shot 2019-09-20 at 00 09 12](https://user-images.githubusercontent.com/3506071/65298825-ef3f4d00-db3a-11e9-9895-7ba149589bd3.png)
![Screen Shot 2019-09-20 at 00 09 19](https://user-images.githubusercontent.com/3506071/65298824-ef3f4d00-db3a-11e9-95bb-78e98c568c54.png)
![Screen Shot 2019-09-20 at 00 09 27](https://user-images.githubusercontent.com/3506071/65298823-ef3f4d00-db3a-11e9-9cfb-19c0fa8b4eea.png)