### PR TITLE
build: enable Ivy for 8.x

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "types": []
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "enableIvy": true
   },
   "files": [
     "src/main.ts",


### PR DESCRIPTION
<!-- 
Filling out this template is required. Do not delete the template when submitting a Pull Request.
-->
## PR Checklist
<!-- Please check verify and then check each option using "x". i.e. "- [x] The..." -->
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/components/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added or weren't appropriate

## What is the current behavior?
Ivy isn't enabled for `8.x`.

Issue Number: N/A

## What is the new behavior?
Ivy is enabled for `8.x`.

## Other information
Current material.angular.io
zipped production bundle - 853 KB
unzipped bundle resources - 4.3 MB

With Ivy enabled
zipped production bundle - 645 KB ✅
unzipped bundle resources - 2.4 MB ✅

Made possible by getting https://github.com/angular/components/pull/17282 and https://github.com/angular/components/pull/17228 merged back to `8.2.3`.