### PR TITLE
refactor: remove duplicate css declaration

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -131,7 +131,6 @@ app-component-sidenav {
       box-sizing: border-box;
       margin: 0;
       max-height: initial;
-      box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
<!-- 
Filling out this template is required. Do not delete the template when submitting a Pull Request.
-->
## PR Checklist
<!-- Please check verify and then check each option using "x". i.e. "- [x] The..." -->
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/components/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added or weren't appropriate

## What is the current behavior?
`box-sizing` is declared twice.

Issue Number: 
Not applicable.

## What is the new behavior?
Removed one instance.

## Other information
I saw this mistake while fixing #550 