### PR TITLE
add option for additional api docs for testing harnesses

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -5,6 +5,7 @@ $sidenav-width: 240px;
 app-component-sidenav {
   display: flex;
   flex-direction: column;
+  overflow: auto;
 }
 
 .docs-component-viewer-sidenav-container {

--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -7,13 +7,13 @@
     <doc-viewer
       documentUrl="/docs-content/api-docs/{{docItem.packageName}}-{{docItem.id}}.html"
       class="docs-component-view-text-content docs-component-api"
-      (contentRendered)="onContentRendered(docItem.name, $event)">
+      (contentRendered)="updateTableOfContents(docItem.name, $event)">
     </doc-viewer>
 
     <doc-viewer *ngFor="let additionalApiDoc of docItem.additionalApiDocs"
       documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
       class="docs-component-view-text-content docs-component-api"
-      (contentRendered)="onContentRendered(additionalApiDoc.name, $event)">
+      (contentRendered)="updateTableOfContents(additionalApiDoc.name, $event)">
     </doc-viewer>
   </span>
 

--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -1,14 +1,23 @@
-<span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
-  API for {{componentViewer.componentDocItem.id}}
-</span>
+<ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
+  <span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
+    API for {{docItem.id}}
+  </span>
 
-<doc-viewer
-    documentUrl="/docs-content/api-docs/{{componentViewer.componentDocItem.packageName}}-{{componentViewer.componentDocItem.id}}.html"
-    class="docs-component-view-text-content docs-component-api"
-    (contentRendered)="scrollToSelectedContentSection()">
-</doc-viewer>
+  <span>
+    <doc-viewer
+      documentUrl="/docs-content/api-docs/{{docItem.packageName}}-{{docItem.id}}.html"
+      class="docs-component-view-text-content docs-component-api"
+      (contentRendered)="onContentRendered(docItem.name, $event)">
+    </doc-viewer>
 
-<table-of-contents #toc
-    *ngIf="showToc | async"
-    headerSelectors=".docs-api-h3,.docs-api-h4"
-    container=".mat-drawer-content"></table-of-contents>
+    <doc-viewer *ngFor="let additionalApiDoc of docItem.additionalApiDocs"
+      documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
+      class="docs-component-view-text-content docs-component-api"
+      (contentRendered)="onContentRendered(additionalApiDoc.name, $event)">
+    </doc-viewer>
+  </span>
+
+  <table-of-contents #toc
+      *ngIf="showToc | async"
+      container=".mat-drawer-content"></table-of-contents>
+</ng-container>

--- a/src/app/pages/component-viewer/component-examples.html
+++ b/src/app/pages/component-viewer/component-examples.html
@@ -1,6 +1,8 @@
-<span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
-  Examples for {{componentViewer.componentDocItem.id}}
-</span>
-<example-viewer
-  *ngFor="let example of componentViewer.componentDocItem.examples"
-  [example]="example"></example-viewer>
+<ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
+  <span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
+    Examples for {{docItem.id}}
+  </span>
+  <example-viewer
+    *ngFor="let example of docItem.examples"
+    [example]="example"></example-viewer>
+</ng-container>

--- a/src/app/pages/component-viewer/component-overview.html
+++ b/src/app/pages/component-viewer/component-overview.html
@@ -5,7 +5,7 @@
   <doc-viewer
       documentUrl="/docs-content/overviews/{{docItem.packageName}}/{{docItem.id}}.html"
       class="docs-component-view-text-content docs-component-overview"
-      (contentRendered)="onContentRendered('Overview Content', $event)">
+      (contentRendered)="updateTableOfContents('Overview Content', $event)">
   </doc-viewer>
   <table-of-contents #toc container=".mat-drawer-content" *ngIf="showToc | async"></table-of-contents>
 </ng-container>

--- a/src/app/pages/component-viewer/component-overview.html
+++ b/src/app/pages/component-viewer/component-overview.html
@@ -1,9 +1,11 @@
-<span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
-  Overview for {{componentViewer.componentDocItem.id}}
-</span>
-<doc-viewer
-    documentUrl="/docs-content/overviews/{{componentViewer.componentDocItem.packageName}}/{{componentViewer.componentDocItem.id}}.html"
-    class="docs-component-view-text-content docs-component-overview"
-    (contentRendered)="scrollToSelectedContentSection()">
-</doc-viewer>
-<table-of-contents #toc container=".mat-drawer-content" *ngIf="showToc | async"></table-of-contents>
+<ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
+  <span class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
+    Overview for {{docItem.id}}
+  </span>
+  <doc-viewer
+      documentUrl="/docs-content/overviews/{{docItem.packageName}}/{{docItem.id}}.html"
+      class="docs-component-view-text-content docs-component-overview"
+      (contentRendered)="onContentRendered('Overview Content', $event)">
+  </doc-viewer>
+  <table-of-contents #toc container=".mat-drawer-content" *ngIf="showToc | async"></table-of-contents>
+</ng-container>

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import {MatTabsModule} from '@angular/material/tabs';
 import {ActivatedRoute, Params, Router, RouterModule} from '@angular/router';
-import {combineLatest, Observable, Subject} from 'rxjs';
+import {combineLatest, Observable, ReplaySubject, Subject} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
 import {DocViewerModule} from '../../shared/doc-viewer/doc-viewer-module';
 import {DocItem, DocumentationItems} from '../../shared/documentation-items/documentation-items';
@@ -26,7 +26,7 @@ import {ComponentPageTitle} from '../page-title/page-title';
   encapsulation: ViewEncapsulation.None,
 })
 export class ComponentViewer implements OnDestroy {
-  componentDocItem: DocItem;
+  componentDocItem = new ReplaySubject<DocItem>(1);
   sections: Set<string> = new Set(['overview', 'api']);
   private _destroyed = new Subject();
 
@@ -47,9 +47,9 @@ export class ComponentViewer implements OnDestroy {
         takeUntil(this._destroyed))
         ).subscribe(d => {
           if (d.doc !== undefined) {
-            this.componentDocItem = d.doc;
-            this._componentPageTitle.title = `${this.componentDocItem.name}`;
-            this.componentDocItem.examples && this.componentDocItem.examples.length ?
+            this.componentDocItem.next(d.doc);
+            this._componentPageTitle.title = `${d.doc.name}`;
+            d.doc.examples && d.doc.examples.length ?
                 this.sections.add('examples') :
                 this.sections.delete('examples');
           } else {
@@ -63,15 +63,13 @@ export class ComponentViewer implements OnDestroy {
   }
 }
 
-@Component({
-  selector: 'component-overview',
-  templateUrl: './component-overview.html',
-  encapsulation: ViewEncapsulation.None,
-})
-export class ComponentOverview implements OnInit {
+export class ComponentBaseView implements OnInit, OnDestroy {
   @ViewChild('initialFocusTarget', {static: false}) focusTarget: ElementRef;
   @ViewChild('toc', {static: false}) tableOfContents: TableOfContents;
+
   showToc: Observable<boolean>;
+
+  destroyed = new Subject<void>();
 
   constructor(public componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
     this.showToc = breakpointObserver.observe('(max-width: 1200px)')
@@ -79,14 +77,35 @@ export class ComponentOverview implements OnInit {
   }
 
   ngOnInit() {
-    // 100ms timeout is used to allow the page to settle before moving focus for screen readers.
-    setTimeout(() => this.focusTarget.nativeElement.focus({preventScroll: true}), 100);
+    this.componentViewer.componentDocItem.pipe(takeUntil(this.destroyed)).subscribe(item => {
+      // 100ms timeout is used to allow the page to settle before moving focus for screen readers.
+      setTimeout(() => this.focusTarget.nativeElement.focus({preventScroll: true}), 100);
+      if (this.tableOfContents) {
+        this.tableOfContents.resetHeaders();
+      }
+    });
   }
 
-  scrollToSelectedContentSection() {
+  ngOnDestroy() {
+    this.destroyed.next();
+  }
+
+  onContentRendered(sectionName: string, docViewerContent: HTMLElement) {
     if (this.tableOfContents) {
+      this.tableOfContents.addHeaders(sectionName, docViewerContent);
       this.tableOfContents.updateScrollPosition();
     }
+  }
+}
+
+@Component({
+  selector: 'component-overview',
+  templateUrl: './component-overview.html',
+  encapsulation: ViewEncapsulation.None,
+})
+export class ComponentOverview extends ComponentBaseView {
+  constructor(componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
+    super(componentViewer, breakpointObserver);
   }
 }
 
@@ -96,14 +115,22 @@ export class ComponentOverview implements OnInit {
   styleUrls: ['./component-api.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class ComponentApi extends ComponentOverview {}
+export class ComponentApi extends ComponentBaseView {
+  constructor(componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
+    super(componentViewer, breakpointObserver);
+  }
+}
 
 @Component({
   selector: 'component-examples',
   templateUrl: './component-examples.html',
   encapsulation: ViewEncapsulation.None,
 })
-export class ComponentExamples extends ComponentOverview {}
+export class ComponentExamples extends ComponentBaseView {
+  constructor(componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
+    super(componentViewer, breakpointObserver);
+  }
+}
 
 @NgModule({
   imports: [

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -63,6 +63,11 @@ export class ComponentViewer implements OnDestroy {
   }
 }
 
+/**
+ * Base component class for views displaying docs on a particular component (overview, API,
+ * examples). Responsible for resetting the focus target on doc item changes and resetting
+ * the table of contents headers.
+ */
 export class ComponentBaseView implements OnInit, OnDestroy {
   @ViewChild('initialFocusTarget', {static: false}) focusTarget: ElementRef;
   @ViewChild('toc', {static: false}) tableOfContents: TableOfContents;
@@ -77,7 +82,7 @@ export class ComponentBaseView implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.componentViewer.componentDocItem.pipe(takeUntil(this.destroyed)).subscribe(item => {
+    this.componentViewer.componentDocItem.pipe(takeUntil(this.destroyed)).subscribe(() => {
       // 100ms timeout is used to allow the page to settle before moving focus for screen readers.
       setTimeout(() => this.focusTarget.nativeElement.focus({preventScroll: true}), 100);
       if (this.tableOfContents) {
@@ -90,7 +95,7 @@ export class ComponentBaseView implements OnInit, OnDestroy {
     this.destroyed.next();
   }
 
-  onContentRendered(sectionName: string, docViewerContent: HTMLElement) {
+  updateTableOfContents(sectionName: string, docViewerContent: HTMLElement) {
     if (this.tableOfContents) {
       this.tableOfContents.addHeaders(sectionName, docViewerContent);
       this.tableOfContents.updateScrollPosition();

--- a/src/app/pages/guide-viewer/guide-viewer.html
+++ b/src/app/pages/guide-viewer/guide-viewer.html
@@ -5,7 +5,7 @@
 <div class="docs-guide-wrapper">
   <div class="docs-guide-toc-and-content">
     <doc-viewer class="docs-guide-content"
-      (contentRendered)="toc.updateScrollPosition()"
+      (contentRendered)="toc.addHeaders('Guide Content', $event); toc.updateScrollPosition()"
       [documentUrl]="guide?.document"></doc-viewer>
     <table-of-contents #toc container="guide-viewer"></table-of-contents>
   </div>

--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -28,6 +28,8 @@ export class DocViewer implements OnDestroy {
   private _portalHosts: DomPortalHost[] = [];
   private _documentFetchSubscription: Subscription;
 
+  @Input() name: string;
+
   /** The URL of the document to display. */
   @Input()
   set documentUrl(url: string | undefined) {
@@ -36,7 +38,7 @@ export class DocViewer implements OnDestroy {
     }
   }
 
-  @Output() contentRendered = new EventEmitter<void>();
+  @Output() contentRendered = new EventEmitter<HTMLElement>();
 
   /** The document text. It should not be HTML encoded. */
   textContent = '';
@@ -88,7 +90,7 @@ export class DocViewer implements OnDestroy {
     // until the Angular zone becomes stable.
     this._ngZone.onStable
       .pipe(take(1))
-      .subscribe(() => this.contentRendered.next());
+      .subscribe(() => this.contentRendered.next(this._elementRef.nativeElement));
   }
 
   /** Show an error that occurred when fetching a document. */

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -1,11 +1,17 @@
 import {Injectable} from '@angular/core';
 
+export interface AdditionalApiDoc {
+  name: string;
+  path: string;
+}
+
 export interface DocItem {
   id: string;
   name: string;
   summary?: string;
   packageName?: string;
   examples?: string[];
+  additionalApiDocs?: AdditionalApiDoc[];
 }
 
 export interface DocCategory {
@@ -57,13 +63,15 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'autocomplete-filter',
             'autocomplete-optgroup',
             'autocomplete-auto-active-first-option',
-          ]
+          ],
+          additionalApiDocs: [{name: 'Testing', path: 'material-autocomplete-testing.html'}],
         },
         {
           id: 'checkbox',
           name: 'Checkbox',
           summary: 'Captures boolean input with an optional indeterminate mode.',
-          examples: ['checkbox-configurable']
+          examples: ['checkbox-configurable'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-checkbox-testing.html'}],
         },
         {
           id: 'datepicker',
@@ -119,7 +127,8 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'radio',
           name: 'Radio button',
           summary: 'Allows the user to select one option from a group.',
-          examples: ['radio-ng-model']
+          examples: ['radio-ng-model'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-radio-testing.html'}],
         },
         {
           id: 'select',
@@ -144,13 +153,15 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'slider',
           name: 'Slider',
           summary: 'Allows the user to input a value by dragging along a slider.',
-          examples: ['slider-configurable']
+          examples: ['slider-configurable'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-slider-testing.html'}],
         },
         {
           id: 'slide-toggle',
           name: 'Slide toggle',
           summary: 'Captures boolean values as a clickable and draggable switch.',
-          examples: ['slide-toggle-configurable']
+          examples: ['slide-toggle-configurable'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-slide-toggle-testing.html'}],
         },
       ]
     },
@@ -167,7 +178,8 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'menu-overview',
             'menu-icons',
             'nested-menu'
-          ]
+          ],
+          additionalApiDocs: [{name: 'Testing', path: 'material-menu-testing.html'}],
         },
         {
           id: 'sidenav',
@@ -183,7 +195,8 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'sidenav-autosize',
             'sidenav-fixed',
             'sidenav-responsive'
-          ]
+          ],
+          additionalApiDocs: [{name: 'Testing', path: 'material-sidenav-testing.html'}],
         },
         {
           id: 'toolbar',
@@ -249,7 +262,9 @@ const DOCS: {[key: string]: DocCategory[]} = {
             'tab-group-theme',
             'tab-group-async',
             'tab-nav-bar-basic',
-          ]},
+          ],
+          additionalApiDocs: [{name: 'Testing', path: 'material-tabs-testing.html'}],
+        },
         {
           id: 'tree',
           name: 'Tree',
@@ -272,7 +287,9 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'button',
           name: 'Button',
           summary: 'An interactive button with a range of presentation options.',
-          examples: ['button-types']},
+          examples: ['button-types'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-button-testing.html'}],
+        },
         {
           id: 'button-toggle',
           name: 'Button toggle',
@@ -306,13 +323,15 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'progress-spinner',
           name: 'Progress spinner',
           summary: 'A circular progress indicator.',
-          examples: ['progress-spinner-configurable']
+          examples: ['progress-spinner-configurable'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-progress-spinner-testing.html'}],
         },
         {
           id: 'progress-bar',
           name: 'Progress bar',
           summary: 'A linear progress indicator.',
-          examples: ['progress-bar-configurable']
+          examples: ['progress-bar-configurable'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-progress-bar-testing.html'}],
         },
         {
           id: 'ripple',
@@ -337,13 +356,15 @@ const DOCS: {[key: string]: DocCategory[]} = {
           id: 'dialog',
           name: 'Dialog',
           summary: 'A configurable modal that displays dynamic content.',
-          examples: ['dialog-overview']
+          examples: ['dialog-overview'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-dialog-testing.html'}],
         },
         {
           id: 'snack-bar',
           name: 'Snackbar',
           summary: 'Displays short actionable messages as an uninvasive alert.',
-          examples: ['snack-bar-component']
+          examples: ['snack-bar-component'],
+          additionalApiDocs: [{name: 'Testing', path: 'material-snack-bar-testing.html'}],
         },
         {
           id: 'tooltip',

--- a/src/app/shared/table-of-contents/table-of-contents.html
+++ b/src/app/shared/table-of-contents/table-of-contents.html
@@ -1,8 +1,8 @@
-<div *ngIf="links?.length" class="docs-toc-container">
-  <div class="docs-toc-heading">Contents</div>
+<div *ngFor="let linkSection of _linkSections" class="docs-toc-container">
+  <div class="docs-toc-heading">{{linkSection.name}}</div>
   <nav>
     <a [href]="_rootUrl + '#' + link.id"
-      *ngFor="let link of links; let i = index"
+      *ngFor="let link of linkSection.links; let i = index"
       class="docs-level-{{link.type}} docs-link"
       [class.docs-active]="link.active">
       {{link.name}}

--- a/src/app/shared/table-of-contents/table-of-contents.scss
+++ b/src/app/shared/table-of-contents/table-of-contents.scss
@@ -7,11 +7,16 @@
   padding-left: 25px;
   box-sizing: border-box;
   display: inline-flex;
+  flex-direction: column;
 }
 
 .docs-toc-container {
   width: 100%;
   padding: 5px 0 10px 10px;
+
+  & + .docs-toc-container {
+    padding-top: 8px;
+  }
 }
 
 .docs-toc-heading {
@@ -19,6 +24,7 @@
   padding: 0;
   font-size: 13px;
   font-weight: bold;
+  text-transform: capitalize;
 }
 
 a {

--- a/src/app/shared/table-of-contents/table-of-contents.spec.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.spec.ts
@@ -39,7 +39,7 @@ describe('TableOfContents', () => {
   });
 
   it('should have header and links', () => {
-    component.links = [
+    component._links = [
       {
         type: 'h2',
         id: 'test',

--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -37,6 +37,8 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   @Input() container: string;
 
   _linkSections: LinkSection[] = [];
+  _links: Link[] = [];
+
   _rootUrl = this._router.url.split('#')[0];
   private _scrollContainer: any;
   private _destroyed = new Subject();
@@ -99,6 +101,7 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
 
   resetHeaders() {
     this._linkSections = [];
+    this._links = [];
   }
 
   addHeaders(sectionName: string, docViewerContent: HTMLElement) {
@@ -117,6 +120,7 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
       });
     });
     this._linkSections.push({name: sectionName, links});
+    this._links.push(...links);
   }
 
   /** Gets the scroll offset of the scroll container */
@@ -130,12 +134,8 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private onScroll(): void {
-    const allLinks: Link[] = [];
-    this._linkSections.forEach(linkSection => {
-      allLinks.push(...linkSection.links);
-    });
-    for (let i = 0; i < allLinks.length; i++) {
-      allLinks[i].active = this.isLinkActive(allLinks[i], allLinks[i + 1]);
+    for (let i = 0; i < this._links.length; i++) {
+      this._links[i].active = this.isLinkActive(this._links[i], this._links[i + 1]);
     }
   }
 

--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -6,6 +6,10 @@ import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 import {Subject, fromEvent} from 'rxjs';
 import {debounceTime, takeUntil} from 'rxjs/operators';
 
+interface LinkSection {
+  name: string;
+  links: Link[];
+}
 
 interface Link {
   /* id of the section*/
@@ -30,11 +34,9 @@ interface Link {
   templateUrl: './table-of-contents.html'
 })
 export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
-
-  @Input() links: Link[] = [];
   @Input() container: string;
-  @Input() headerSelectors = '.docs-markdown h3, .docs-markdown h4';
 
+  _linkSections: LinkSection[] = [];
   _rootUrl = this._router.url.split('#')[0];
   private _scrollContainer: any;
   private _destroyed = new Subject();
@@ -49,7 +51,6 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
       if (event instanceof NavigationEnd) {
         const rootUrl = _router.url.split('#')[0];
         if (rootUrl !== this._rootUrl) {
-          this.links = this.createLinks();
           this._rootUrl = rootUrl;
         }
       }
@@ -90,12 +91,32 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   updateScrollPosition(): void {
-    this.links = this.createLinks();
-
     const target = document.getElementById(this._urlFragment);
     if (target) {
       target.scrollIntoView();
     }
+  }
+
+  resetHeaders() {
+    this._linkSections = [];
+  }
+
+  addHeaders(sectionName: string, docViewerContent: HTMLElement) {
+    const headers = docViewerContent.querySelectorAll('h3, h4');
+    const links: Link[] = [];
+    headers.forEach((header: HTMLElement) => {
+      // remove the 'link' icon name from the inner text
+      const name = header.innerText.trim().replace(/^link/, '');
+      const {top} = header.getBoundingClientRect();
+      links.push({
+        name,
+        type: header.tagName.toLowerCase(),
+        top: top,
+        id: header.id,
+        active: false
+      });
+    });
+    this._linkSections.push({name: sectionName, links});
   }
 
   /** Gets the scroll offset of the scroll container */
@@ -108,32 +129,13 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  private createLinks(): Link[] {
-    const links: Array<Link> = [];
-    const headers =
-        Array.from(this._document.querySelectorAll(this.headerSelectors)) as HTMLElement[];
-
-    if (headers.length) {
-      for (const header of headers) {
-        // remove the 'link' icon name from the inner text
-        const name = header.innerText.trim().replace(/^link/, '');
-        const {top} = header.getBoundingClientRect();
-        links.push({
-          name,
-          type: header.tagName.toLowerCase(),
-          top: top,
-          id: header.id,
-          active: false
-        });
-      }
-    }
-
-    return links;
-  }
-
   private onScroll(): void {
-    for (let i = 0; i < this.links.length; i++) {
-      this.links[i].active = this.isLinkActive(this.links[i], this.links[i + 1]);
+    const allLinks: Link[] = [];
+    this._linkSections.forEach(linkSection => {
+      allLinks.push(...linkSection.links);
+    });
+    for (let i = 0; i < allLinks.length; i++) {
+      allLinks[i].active = this.isLinkActive(allLinks[i], allLinks[i + 1]);
     }
   }
 


### PR DESCRIPTION
Allows the API tab to include additional documentation files to be added to the page, making sure the table of contents also updates with them.

Primary objective is to allow the testing harness API docs to be appended to the component API page, e.g. button harness APIs will show up after the button APIs