### PR TITLE
fix(stack-blitz-button): use theme's currentColor

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-button.html
+++ b/src/app/shared/stack-blitz/stack-blitz-button.html
@@ -8,7 +8,7 @@
         <title>StackBlitz Logo</title>
         <desc>Created with Sketch.</desc>
         <g id='Symbols' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'>
-          <g fill='#1389FD' fill-rule='nonzero'>
+          <g id="stack-blitz-fill-group" fill-rule='nonzero'>
             <polygon id='Path'
                      points='0 19.9187087 9.87007874 19.9187087 4.12007874 34 23 13.9612393 13.0846457 13.9612393 18.7893701 0'>
             </polygon>

--- a/src/app/shared/stack-blitz/stack-blitz-button.scss
+++ b/src/app/shared/stack-blitz/stack-blitz-button.scss
@@ -1,0 +1,3 @@
+#stack-blitz-fill-group {
+  fill: currentColor;
+}

--- a/src/app/shared/stack-blitz/stack-blitz-button.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-button.ts
@@ -8,6 +8,7 @@ import {StackBlitzWriter} from './stack-blitz-writer';
 @Component({
   selector: 'stack-blitz-button',
   templateUrl: './stack-blitz-button.html',
+  styleUrls: ['./stack-blitz-button.scss'],
   providers: [StackBlitzWriter],
   host: {
     '(mouseover)': 'isDisabled = !stackBlitzForm'


### PR DESCRIPTION
instead of StackBlitz branding color

Fixes #662

![Screen Shot 2019-10-22 at 03 39 48](https://user-images.githubusercontent.com/3506071/67266492-63447c00-f47e-11e9-9e4f-b106f79a1a22.png)
![Screen Shot 2019-10-22 at 03 39 41](https://user-images.githubusercontent.com/3506071/67266493-63447c00-f47e-11e9-8848-3d9cb629c03a.png)
