### PR TITLE
fix: apply updates from master to 8.x branch

### DIFF
--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -2,7 +2,7 @@
 <div class="docs-component-category-list">
   <a *ngFor="let category of docItems.getCategories((params | async)?.section)"
      class="docs-component-category-list-item"
-    [routerLink]="['../', category.id]">
+    [routerLink]="[category.id]">
     <mat-card class="docs-component-category-list-card">
       <mat-card-title>{{category.name}}</mat-card-title>
       <mat-card-content class="docs-component-category-list-card-summary">{{category.summary}}</mat-card-content>

--- a/src/app/shared/stack-blitz/stack-blitz-button.html
+++ b/src/app/shared/stack-blitz/stack-blitz-button.html
@@ -2,19 +2,6 @@
   <button mat-icon-button type="button"
           (click)="openStackBlitz()"
           [disabled]="isDisabled">
-    <mat-icon>
-      <svg width='24px' height='24px' viewBox='0 -3 23 40' version='1.1'
-           xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>
-        <title>StackBlitz Logo</title>
-        <desc>Created with Sketch.</desc>
-        <g id='Symbols' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'>
-          <g fill='#1389FD' fill-rule='nonzero'>
-            <polygon id='Path'
-                     points='0 19.9187087 9.87007874 19.9187087 4.12007874 34 23 13.9612393 13.0846457 13.9612393 18.7893701 0'>
-            </polygon>
-          </g>
-        </g>
-      </svg>
-    </mat-icon>
+    <mat-icon>open_in_new</mat-icon>
   </button>
 </div>


### PR DESCRIPTION
fix(category-list): bad routerLink path with relativeLinkResolution (#663)

needed with the router's `relativeLinkResolution: 'corrected'`

Fixes #661

fix(stack-blitz-button): use open_in_new icon (#667)

Fixes #662