### PR TITLE
fix: header not working correctly

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -115,6 +115,12 @@ app-component-sidenav {
 .docs-component-sidenav-body-content {
   display: flex;
   flex: 1 1 auto;
+  overflow-x: auto;
+  overflow: -moz-scrollbars-none;
+}
+
+.docs-component-sidenav-body-content::-webkit-scrollbar {
+  display: none;
 }
 
 @media (max-width: $small-breakpoint-width) {


### PR DESCRIPTION
Fixes #686

The header is not working correctly when content takes more width than the viewport. Check the attached screenshot. Now make the body scroll if it takes more with than the screen.

![Datepicker   Angular Material (2)](https://user-images.githubusercontent.com/39260684/70200893-f38f0580-173a-11ea-9a0c-36341302e861.png)
