### PR TITLE
build: enable strictTemplates, strictBindCallApply, and strictFunctionTypes

### DIFF
--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -1,5 +1,5 @@
 import {Component, ViewEncapsulation} from '@angular/core';
-import {Router, NavigationEnd} from '@angular/router';
+import {Event, NavigationEnd, Router} from '@angular/router';
 import {filter} from 'rxjs/operators';
 
 import {GaService} from './shared/ga/ga';
@@ -16,16 +16,17 @@ export class MaterialDocsApp {
     let previousRoute = router.routerState.snapshot.url;
 
     router.events
-      .pipe(filter(event => event instanceof NavigationEnd))
-      .subscribe((data: NavigationEnd) => {
+      .pipe(filter((event: Event) => event instanceof NavigationEnd))
+      .subscribe((data: Event) => {
+        const urlAfterRedirects = (data as NavigationEnd).urlAfterRedirects;
         // We want to reset the scroll position on navigation except when navigating within
         // the documentation for a single component.
-        if (!isNavigationWithinComponentView(previousRoute, data.urlAfterRedirects)) {
+        if (!isNavigationWithinComponentView(previousRoute, urlAfterRedirects)) {
           resetScrollPosition();
         }
 
-        previousRoute = data.urlAfterRedirects;
-        ga.locationChanged(data.urlAfterRedirects);
+        previousRoute = urlAfterRedirects;
+        ga.locationChanged(urlAfterRedirects);
       });
   }
 }

--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -105,9 +105,9 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   addHeaders(sectionName: string, docViewerContent: HTMLElement) {
-    const headers = docViewerContent.querySelectorAll('h3, h4');
+    const headers = Array.from<HTMLHeadingElement>(docViewerContent.querySelectorAll('h3, h4'));
     const links: Link[] = [];
-    headers.forEach((header: HTMLElement) => {
+    headers.forEach((header) => {
       // remove the 'link' icon name from the inner text
       const name = header.innerText.trim().replace(/^link/, '');
       const {top} = header.getBoundingClientRect();

--- a/src/app/shared/theme-picker/theme-picker.ts
+++ b/src/app/shared/theme-picker/theme-picker.ts
@@ -1,13 +1,13 @@
 import {
-  Component,
-  ViewEncapsulation,
   ChangeDetectionStrategy,
+  Component,
   NgModule,
-  OnInit,
   OnDestroy,
+  OnInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import {StyleManager} from '../style-manager';
-import {ThemeStorage, DocsSiteTheme} from './theme-storage/theme-storage';
+import {DocsSiteTheme, ThemeStorage} from './theme-storage/theme-storage';
 import {MatButtonModule} from '@angular/material/button';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {MatIconModule} from '@angular/material/icon';
@@ -16,8 +16,7 @@ import {MatTooltipModule} from '@angular/material/tooltip';
 import {CommonModule} from '@angular/common';
 import {ActivatedRoute, ParamMap} from '@angular/router';
 import {Subscription} from 'rxjs';
-import {map, filter} from 'rxjs/operators';
-
+import {map} from 'rxjs/operators';
 
 @Component({
   selector: 'theme-picker',
@@ -71,8 +70,12 @@ export class ThemePicker implements OnInit, OnDestroy {
 
   ngOnInit() {
     this._queryParamSubscription = this._activatedRoute.queryParamMap
-      .pipe(map((params: ParamMap) => params.get('theme')), filter(Boolean))
-      .subscribe((themeName: string) => this.installTheme(themeName));
+      .pipe(map((params: ParamMap) => params.get('theme')))
+      .subscribe((themeName: string | null) => {
+        if (themeName) {
+          this.installTheme(themeName);
+        }
+    });
   }
 
   ngOnDestroy() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,13 +22,17 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noFallthroughCasesInSwitch": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "exclude": [
-    "src/assets"
+    "src/assets",
+    "dist"
   ],
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
- enable Ivy's strict Template Type Checking
- fix related build errors
- complete `this._destroyed` in `ngOnDestroy()`
- exclude `dist/` from linting

`strictPropertyInitialization` is a bit more problematic, so it will be handled in a separate PR.