### PR TITLE
fix(stack-blitz): default to form-field fill appearance

### DIFF
--- a/src/assets/stack-blitz/src/main.ts
+++ b/src/assets/stack-blitz/src/main.ts
@@ -8,9 +8,13 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {DemoMaterialModule} from './app/material-module';
+import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 
 import {MaterialDocsExample} from './app/material-docs-example';
 
+// Default MatFormField appearance to 'fill' as that is the new recommended approach and the
+// `legacy` and `standard` appearances are scheduled for deprecation in version 10.
+// This makes the examples that use MatFormField render the same in StackBlitz as on the docs site.
 @NgModule({
   imports: [
     BrowserModule,
@@ -24,7 +28,9 @@ import {MaterialDocsExample} from './app/material-docs-example';
   entryComponents: [MaterialDocsExample],
   declarations: [MaterialDocsExample],
   bootstrap: [MaterialDocsExample],
-  providers: []
+  providers: [
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'fill' } },
+  ]
 })
 export class AppModule {}
 


### PR DESCRIPTION
Can be tested via https://angularmaterial.dev/components/datepicker/examples

Relates to https://github.com/angular/components/issues/14792 and https://github.com/angular/components/pull/18252.

This should go into `master` ASAP for the v9 final release.