### PR TITLE
fix: cdk test harness API document not found

### DIFF
--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -3,8 +3,7 @@
     API for {{docItem?.id}}
   </span>
 
-  <doc-viewer
-    documentUrl="/docs-content/api-docs/{{docItem?.packageName}}-{{docItem?.id}}.html"
+  <doc-viewer [documentUrl]="getApiDocumentUrl(docItem!)"
     class="docs-component-view-text-content docs-component-api"
     (contentRendered)="updateTableOfContents(docItem!.name, $event)">
   </doc-viewer>

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -128,6 +128,11 @@ export class ComponentApi extends ComponentBaseView {
   constructor(componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
     super(componentViewer, breakpointObserver);
   }
+
+  getApiDocumentUrl(doc: DocItem) {
+    const apiDocId = doc.apiDocId || `${doc.packageName}-${doc.id}`;
+    return `/docs-content/api-docs/${apiDocId}.html`;
+  }
 }
 
 @Component({

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -11,6 +11,7 @@ export interface DocItem {
   summary?: string;
   packageName?: string;
   examples?: string[];
+  apiDocId?: string;
   additionalApiDocs?: AdditionalApiDoc[];
 }
 
@@ -563,6 +564,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
           name: 'Component Harnesses',
           summary: 'Foundation for component test harnesses.',
           examples: [],
+          apiDocId: 'cdk-testing',
           additionalApiDocs: [
             {
               name: 'Testbed',


### PR DESCRIPTION
The CDK test harness documentation API has `test-harnesses` as id. This
doesn't match any generated API document since the API doc for
`@angular/cdk/testing` is generated with the `cdk-testing` id.

We should add support for custom API doc ids that differ from the
actual doc entry id in order to fix this issue.

Fixes angular/components#18426