### PR TITLE
fix: components with multiple API docs do not display correctly

### DIFF
--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -3,16 +3,23 @@
     API for {{docItem?.id}}
   </span>
 
-  <doc-viewer [documentUrl]="getApiDocumentUrl(docItem!)"
-    class="docs-component-view-text-content docs-component-api"
-    (contentRendered)="updateTableOfContents(docItem!.name, $event)">
-  </doc-viewer>
+  <!--
+  The span container is necessary for the layout to display properly. When
+  a component has multiple API docs, they need to be joined together in the
+  same container so that they display one after another.
+  -->
+  <span>
+    <doc-viewer [documentUrl]="getApiDocumentUrl(docItem!)"
+      class="docs-component-view-text-content docs-component-api"
+      (contentRendered)="updateTableOfContents(docItem!.name, $event)">
+    </doc-viewer>
 
-  <doc-viewer *ngFor="let additionalApiDoc of docItem!.additionalApiDocs"
-    documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
-    class="docs-component-view-text-content docs-component-api"
-    (contentRendered)="updateTableOfContents(additionalApiDoc.name, $event)">
-  </doc-viewer>
+    <doc-viewer *ngFor="let additionalApiDoc of docItem!.additionalApiDocs"
+      documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
+      class="docs-component-view-text-content docs-component-api"
+      (contentRendered)="updateTableOfContents(additionalApiDoc.name, $event)">
+    </doc-viewer>
+  </span>
 
   <table-of-contents #toc
       *ngIf="showToc | async"


### PR DESCRIPTION
Currently the docs look like this on pages with additional API docs (test harness docs)

![0DPPY2s8RAN](https://user-images.githubusercontent.com/22898577/74052560-fb636400-498e-11ea-9988-a0f1b4af6791.png)
