### PR TITLE
refactor: account for collision avoidance changes to docs-content

### DIFF
--- a/src/app/pages/component-viewer/component-overview.html
+++ b/src/app/pages/component-viewer/component-overview.html
@@ -2,8 +2,7 @@
   <h2 class="cdk-visually-hidden" tabindex="-1" #initialFocusTarget>
     Overview for {{docItem?.id}}
   </h2>
-  <doc-viewer
-      documentUrl="/docs-content/overviews/{{docItem?.packageName}}/{{docItem?.id}}.html"
+  <doc-viewer [documentUrl]="getOverviewDocumentUrl(docItem!)"
       class="docs-component-view-text-content docs-component-overview"
       (contentRendered)="updateTableOfContents('Overview Content', $event)">
   </doc-viewer>

--- a/src/app/pages/component-viewer/component-viewer.ts
+++ b/src/app/pages/component-viewer/component-viewer.ts
@@ -116,6 +116,16 @@ export class ComponentOverview extends ComponentBaseView {
   constructor(componentViewer: ComponentViewer, breakpointObserver: BreakpointObserver) {
     super(componentViewer, breakpointObserver);
   }
+
+  getOverviewDocumentUrl(doc: DocItem) {
+    // Use the explicit overview path if specified. Otherwise, compute an overview path based
+    // on the package name and doc item id. Overviews for components are commonly stored in a
+    // folder named after the component while the overview file is named similarly. e.g.
+    //    `cdk#overlay`     -> `cdk/overlay/overlay.md`
+    //    `material#button` -> `material/button/button.md`
+    const overviewPath = doc.overviewPath || `${doc.packageName}/${doc.id}/${doc.id}.html`;
+    return `/docs-content/overviews/${overviewPath}`;
+  }
 }
 
 @Component({

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -6,12 +6,21 @@ export interface AdditionalApiDoc {
 }
 
 export interface DocItem {
+  /** Id of the doc item. Used in the URL for linking to the doc. */
   id: string;
+  /** Display name of the doc item. */
   name: string;
+  /** Short summary of the doc item. */
   summary?: string;
+  /** Package which contains the doc item. */
   packageName?: string;
+  /** List of examples. */
   examples?: string[];
+  /** Optional id of the API document file. */
   apiDocId?: string;
+  /** Optional path to the overview file of this doc item. */
+  overviewPath?: string;
+  /** List of additional API docs. */
   additionalApiDocs?: AdditionalApiDoc[];
 }
 
@@ -566,6 +575,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
           name: 'Component Harnesses',
           summary: 'Foundation for component test harnesses.',
           examples: [],
+          overviewPath: 'cdk/testing/test-harnesses.html',
           apiDocId: 'cdk-testing',
           additionalApiDocs: [
             {

--- a/src/app/shared/stack-blitz/stack-blitz-button.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-button.ts
@@ -30,7 +30,7 @@ export class StackBlitzButton {
     this.exampleData = new ExampleData(example);
 
     if (example) {
-      this.stackBlitzWriter.constructStackBlitzForm(this.exampleData)
+      this.stackBlitzWriter.constructStackBlitzForm(example, this.exampleData)
       .then((stackBlitzForm: HTMLFormElement) => {
         this.stackBlitzForm = stackBlitzForm;
         this.isDisabled = false;

--- a/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
@@ -1,8 +1,9 @@
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {async, fakeAsync, flushMicrotasks, inject, TestBed} from '@angular/core/testing';
-import {ExampleData} from '@angular/components-examples';
+import {EXAMPLE_COMPONENTS, ExampleData, LiveExample} from '@angular/components-examples';
 import {StackBlitzWriter} from './stack-blitz-writer';
 
+const testExampleId = 'my-test-example-id';
 
 describe('StackBlitzWriter', () => {
   let stackBlitzWriter: StackBlitzWriter;
@@ -28,6 +29,14 @@ describe('StackBlitzWriter', () => {
     data = new ExampleData('');
     data.componentNames = [];
     data.exampleFiles = ['test.ts', 'test.html', 'src/detail.ts'];
+
+    // Fake the example in the `EXAMPLE_COMPONENTS`. The stack blitz writer relies on
+    // module information for the example in order to read the example sources from disk.
+    EXAMPLE_COMPONENTS[testExampleId] = {module: {importSpecifier: 'cdk/my-comp'}} as LiveExample;
+  });
+
+  afterEach(() => {
+    delete EXAMPLE_COMPONENTS[testExampleId];
   });
 
   it('should append correct copyright', () => {
@@ -66,7 +75,7 @@ describe('StackBlitzWriter', () => {
 
   it('should open a new window with stackblitz url', fakeAsync(() => {
     let form: HTMLFormElement;
-    stackBlitzWriter.constructStackBlitzForm(data).then((result: HTMLFormElement) => {
+    stackBlitzWriter.constructStackBlitzForm(testExampleId, data).then(result => {
       form = result;
       flushMicrotasks();
 
@@ -116,7 +125,7 @@ const TEST_URLS = [
   '/assets/stack-blitz/src/polyfills.ts',
   '/assets/stack-blitz/src/main.ts',
   '/assets/stack-blitz/src/app/material-module.ts',
-  '/docs-content/examples-source/test.ts',
-  '/docs-content/examples-source/test.html',
-  '/docs-content/examples-source/src/detail.ts',
+  `/docs-content/examples-source/cdk/my-comp/${testExampleId}/test.ts`,
+  `/docs-content/examples-source/cdk/my-comp/${testExampleId}/test.html`,
+  `/docs-content/examples-source/cdk/my-comp/${testExampleId}/src/detail.ts`,
 ];

--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -1,7 +1,7 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {VERSION} from '@angular/material/core';
-import {ExampleData} from '@angular/components-examples';
+import {EXAMPLE_COMPONENTS, ExampleData} from '@angular/components-examples';
 
 import {materialVersion} from '../version/version';
 
@@ -17,7 +17,7 @@ const COPYRIGHT =
  * structure is defined in the Material repository, but we include the docs-content as assets in
  * in the CLI configuration.
  */
-const DOCS_CONTENT_PATH = '/docs-content/examples-source/';
+const DOCS_CONTENT_PATH = '/docs-content/examples-source';
 
 const TEMPLATE_PATH = '/assets/stack-blitz/';
 const TEMPLATE_FILES = [
@@ -87,9 +87,12 @@ export class StackBlitzWriter {
    * Returns an HTMLFormElement that will open a new StackBlitz template with the example data when
    * called with submit().
    */
-  constructStackBlitzForm(data: ExampleData): Promise<HTMLFormElement> {
+  constructStackBlitzForm(exampleId: string, data: ExampleData): Promise<HTMLFormElement> {
+    const liveExample = EXAMPLE_COMPONENTS[exampleId];
     const indexFile = `src%2Fapp%2F${data.indexFilename}.ts`;
     const form = this._createFormElement(indexFile);
+    const baseExamplePath =
+        `${DOCS_CONTENT_PATH}/${liveExample.module.importSpecifier}/${exampleId}/`;
 
     TAGS.forEach((tag, i) => this._appendFormInput(form, `tags[${i}]`, tag));
     this._appendFormInput(form, 'private', 'true');
@@ -101,7 +104,7 @@ export class StackBlitzWriter {
           .map(file => this._readFile(form, data, file, TEMPLATE_PATH));
 
       const exampleContents = data.exampleFiles
-          .map(file => this._readFile(form, data, file, DOCS_CONTENT_PATH));
+          .map(file => this._readFile(form, data, file, baseExamplePath));
 
       // TODO(josephperrott): Prevent including assets to be manually checked.
       if (data.selectorName === 'icon-svg-example') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,13 +187,9 @@
   resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-9.0.0.tgz#87e0bef4c369b6cadae07e3a4295778fc93799d5"
   integrity sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==
 
-"@angular/components-examples@angular/material2-docs-content#9.0.x":
-  version "9.0.1-sha-2454e1859"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/610ff8f72e2ae0e56bf115b4f00f5a6b570d7ac0"
-
 "@angular/components-examples@angular/material2-docs-content#master":
-  version "9.1.0-sha-220447eb0"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/288ba52a9cf203affe8400285d8c0d4c846cef76"
+  version "9.1.0-sha-ef1673594"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/f6160a6a3a43b3c002ada67908add68e9f9d84d5"
 
 "@angular/core@9.0.0":
   version "9.0.0"


### PR DESCRIPTION
With https://github.com/angular/components/commit/ce22f1b3444ad006f00cb95f338e6f2e142d559b, we changed how the docs-content
is composed. Instead of always putting all files at the top-level
of the `docs-content/`, files are now nested based on their structure
in `angular/components` repository. This ensures that there no collisions
for such files, and that multiple files with same file can exist in the docs-content.

The docs app needs to be updated to account for these new paths.