### PR TITLE
Follow up to example-viewer for collision docs-content change

### DIFF
--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -18,6 +18,7 @@ import {ExampleViewer} from './example-viewer';
 import {AutocompleteExamplesModule} from '@angular/components-examples/material/autocomplete';
 
 const exampleKey = 'autocomplete-overview';
+const exampleBasePath = `/docs-content/examples-highlighted/material/autocomplete/${exampleKey}`;
 
 
 describe('ExampleViewer', () => {
@@ -75,10 +76,9 @@ describe('ExampleViewer', () => {
 
     // get example file path for each extension
     const extensions = ['ts', 'css', 'html'];
-    const basePath = '/docs-content/examples-highlighted/';
 
     extensions.forEach(extension => {
-      const expected = `${basePath}${exampleKey}-example-${extension}.html`;
+      const expected = `${exampleBasePath}/${exampleKey}-example-${extension}.html`;
       const actual = component.exampleTabs[extension.toUpperCase()];
 
       expect(actual).toEqual(expected);
@@ -176,10 +176,8 @@ class TestExampleModule { }
 
 
 const FAKE_DOCS: {[key: string]: string} = {
-  '/docs-content/examples-highlighted/autocomplete-overview-example-html.html':
-      '<div>my docs page</div>',
-  '/docs-content/examples-highlighted/autocomplete-overview-example-ts.html':
-      '<span>const a = 1;</span>',
-  '/docs-content/examples-highlighted/autocomplete-overview-example-css.html':
+  [`${exampleBasePath}/autocomplete-overview-example-html.html`]: '<div>my docs page</div>',
+  [`${exampleBasePath}/autocomplete-overview-example-ts.html`]: '<span>const a = 1;</span>',
+  [`${exampleBasePath}/autocomplete-overview-example-css.html`]:
       '<pre>.class { color: black; }</pre>',
 };

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -81,15 +81,14 @@ export class ExampleViewer {
     this._exampleModuleFactory = new ɵNgModuleFactory(moduleExports[module.name]);
   }
 
-  private resolveHighlightedExampleFile(fileName: string) {
-    return `/docs-content/examples-highlighted/${fileName}`;
-  }
-
   private _generateExampleTabs() {
+    const examplePath = `${this.exampleData.module.importSpecifier}/${this.example}`;
+    const docsContentPath = `/docs-content/examples-highlighted/${examplePath}`;
+
     this.exampleTabs = {
-      HTML: this.resolveHighlightedExampleFile(`${this.example}-example-html.html`),
-      TS: this.resolveHighlightedExampleFile(`${this.example}-example-ts.html`),
-      CSS: this.resolveHighlightedExampleFile(`${this.example}-example-css.html`),
+      HTML: `${docsContentPath}/${this.example}-example-html.html`,
+      TS: `${docsContentPath}/${this.example}-example-ts.html`,
+      CSS: `${docsContentPath}/${this.example}-example-css.html`,
     };
 
     const additionalFiles = this.exampleData.additionalFiles || [];
@@ -98,7 +97,7 @@ export class ExampleViewer {
       // Since the additional files refer to the original file name, we need to transform
       // the file name to match the highlighted HTML file that displays the source.
       const fileSourceName = fileName.replace(fileExtensionRegex, '$1-$2.html');
-      this.exampleTabs[fileName] = this.resolveHighlightedExampleFile(fileSourceName);
+      this.exampleTabs[fileName] = `${docsContentPath}/${fileSourceName}`;
     });
   }
 }


### PR DESCRIPTION
The recent changes to account for the docs-content have been merged. Unfortunately though it seems like parts of the changes have been lost (for the highlighted example files) for whatever reason (maybe rebasing).

This follow-up PR adds the remaining parts needed to account for the docs-content restructure. It ensures that the highlighted example files can be loaded in the docs.