### PR TITLE
fix: ripple overview not loading

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -346,6 +346,7 @@ const DOCS: {[key: string]: DocCategory[]} = {
         {
           id: 'ripple',
           name: 'Ripples',
+          overviewPath: 'material/core/ripple/ripple.html',
           summary: 'Directive for adding Material Design ripple effects',
           examples: ['ripple-overview']
         }


### PR DESCRIPTION
The ripple overview does not load currently because it's a special
generated file that does not match an entry-point, and is nested
under `material/core/ripple`. This does not match other documentation
items for which we infer the overview path based on the doc item `id`.