### PR TITLE
refactor: create a service to manage navigation & focus state in the docs app

### DIFF
--- a/src/app/material-docs-app.scss
+++ b/src/app/material-docs-app.scss
@@ -26,10 +26,6 @@ material-docs-app > guide-viewer {
   overflow-y: auto;
 }
 
-#main-content {
-  outline: none;
-}
-
 @media (max-width: 720px) {
   material-docs-app {
     top: 92px;

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -3,7 +3,6 @@ import {Event, NavigationEnd, Router} from '@angular/router';
 import {filter} from 'rxjs/operators';
 
 import {GaService} from './shared/ga/ga';
-import {NavigationFocusService} from './shared/navigation-focus/navigation-focus.service';
 
 @Component({
   selector: 'material-docs-app',

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -1,8 +1,9 @@
-import {Component, ViewEncapsulation} from '@angular/core';
-import {Event, NavigationEnd, Router} from '@angular/router';
+import {Component, OnDestroy, ViewEncapsulation} from '@angular/core';
 
 import {GaService} from './shared/ga/ga';
 import {NavigationFocusService} from './shared/navigation-focus/navigation-focus.service';
+import {Subscription} from 'rxjs';
+import {map, pairwise, startWith} from 'rxjs/operators';
 
 @Component({
   selector: 'material-docs-app',
@@ -10,31 +11,27 @@ import {NavigationFocusService} from './shared/navigation-focus/navigation-focus
   styleUrls: ['./material-docs-app.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class MaterialDocsApp {
-  constructor(router: Router, ga: GaService, navigationFocusService: NavigationFocusService) {
-    let previousRoute = router.routerState.snapshot.url;
-    navigationFocusService.navigationEndEvents .subscribe((data: Event) => {
-      const urlAfterRedirects = (data as NavigationEnd).urlAfterRedirects;
+export class MaterialDocsApp implements OnDestroy {
+  private subscriptions = new Subscription();
+
+  constructor(ga: GaService, navigationFocusService: NavigationFocusService) {
+    this.subscriptions.add(navigationFocusService.navigationEndEvents.pipe(
+      map(e => e.urlAfterRedirects),
+      startWith(''),
+      pairwise()
+    ).subscribe(([fromUrl, toUrl]) => {
       // We want to reset the scroll position on navigation except when navigating within
       // the documentation for a single component.
-      if (!isNavigationWithinComponentView(previousRoute, urlAfterRedirects)) {
+      if (!navigationFocusService.isNavigationWithinComponentView(fromUrl, toUrl)) {
         resetScrollPosition();
       }
-      previousRoute = urlAfterRedirects;
-      ga.locationChanged(urlAfterRedirects);
-    });
+      ga.locationChanged(toUrl);
+    }));
   }
-}
 
-function isNavigationWithinComponentView(previousUrl: string, newUrl: string) {
-  const componentViewExpression = /(cdk|components)\/(\w+)/;
-
-  const previousUrlMatch = previousUrl.match(componentViewExpression);
-  const newUrlMatch = newUrl.match(componentViewExpression);
-
-  return previousUrl && newUrl && previousUrlMatch && newUrlMatch
-      && previousUrlMatch[0] === newUrlMatch[0]
-      && previousUrlMatch[1] === newUrlMatch[1];
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
 }
 
 function resetScrollPosition() {

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -3,6 +3,7 @@ import {Event, NavigationEnd, Router} from '@angular/router';
 import {filter} from 'rxjs/operators';
 
 import {GaService} from './shared/ga/ga';
+import {NavigationFocusService} from './shared/navigation-focus/navigation-focus.service';
 
 @Component({
   selector: 'material-docs-app',

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -1,8 +1,8 @@
 import {Component, ViewEncapsulation} from '@angular/core';
 import {Event, NavigationEnd, Router} from '@angular/router';
-import {filter} from 'rxjs/operators';
 
 import {GaService} from './shared/ga/ga';
+import {NavigationFocusService} from './shared/navigation-focus/navigation-focus.service';
 
 @Component({
   selector: 'material-docs-app',
@@ -11,20 +11,18 @@ import {GaService} from './shared/ga/ga';
   encapsulation: ViewEncapsulation.None,
 })
 export class MaterialDocsApp {
-  constructor(router: Router, ga: GaService) {
+  constructor(router: Router, ga: GaService, navigationFocusService: NavigationFocusService) {
     let previousRoute = router.routerState.snapshot.url;
-    router.events
-      .pipe(filter((event: Event) => event instanceof NavigationEnd))
-      .subscribe((data: Event) => {
-        const urlAfterRedirects = (data as NavigationEnd).urlAfterRedirects;
-        // We want to reset the scroll position on navigation except when navigating within
-        // the documentation for a single component.
-        if (!isNavigationWithinComponentView(previousRoute, urlAfterRedirects)) {
-          resetScrollPosition();
-        }
-        previousRoute = urlAfterRedirects;
-        ga.locationChanged(urlAfterRedirects);
-      });
+    navigationFocusService.navigationEndEvents .subscribe((data: Event) => {
+      const urlAfterRedirects = (data as NavigationEnd).urlAfterRedirects;
+      // We want to reset the scroll position on navigation except when navigating within
+      // the documentation for a single component.
+      if (!isNavigationWithinComponentView(previousRoute, urlAfterRedirects)) {
+        resetScrollPosition();
+      }
+      previousRoute = urlAfterRedirects;
+      ga.locationChanged(urlAfterRedirects);
+    });
   }
 }
 

--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -1,4 +1,7 @@
-<div class="docs-component-category-list-summary" focusOnNavigation tabindex="-1">{{_categoryListSummary}}</div>
+<div class="docs-component-category-list-summary"
+     id="category-summary"
+     focusOnNavigation
+     tabindex="-1">{{_categoryListSummary}}</div>
 <div class="docs-component-category-list">
   <a *ngFor="let category of docItems.getCategories((params | async)?.section)"
      class="docs-component-category-list-item"

--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -1,4 +1,4 @@
-<div class="docs-component-category-list-summary" focusOnNavigation id="main-content" tabindex="-1">{{_categoryListSummary}}</div>
+<div class="docs-component-category-list-summary" focusOnNavigation tabindex="-1">{{_categoryListSummary}}</div>
 <div class="docs-component-category-list">
   <a *ngFor="let category of docItems.getCategories((params | async)?.section)"
      class="docs-component-category-list-item"

--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -1,7 +1,6 @@
 <div class="docs-component-category-list-summary"
      id="category-summary"
-     focusOnNavigation
-     tabindex="-1">{{_categoryListSummary}}</div>
+     focusOnNavigation>{{_categoryListSummary}}</div>
 <div class="docs-component-category-list">
   <a *ngFor="let category of docItems.getCategories((params | async)?.section)"
      class="docs-component-category-list-item"

--- a/src/app/pages/component-list/component-list.html
+++ b/src/app/pages/component-list/component-list.html
@@ -1,4 +1,4 @@
-<div class="docs-component-list-category">
+<div class="docs-component-list-category" focusOnNavigation id="component-list">
   <a *ngFor="let component of category?.items"
     class="docs-component-list-item"
     [routerLink]="'/' + section + '/' + component.id">

--- a/src/app/pages/component-list/component-list.ts
+++ b/src/app/pages/component-list/component-list.ts
@@ -9,6 +9,7 @@ import {SvgViewerModule} from '../../shared/svg-viewer/svg-viewer';
 import {CommonModule} from '@angular/common';
 import {MatCardModule } from '@angular/material/card';
 import {combineLatest} from 'rxjs';
+import {NavigationFocusModule} from '../../shared/navigation-focus/navigation-focus';
 
 @Component({
   selector: 'app-components',
@@ -38,7 +39,7 @@ export class ComponentList {
 }
 
 @NgModule({
-  imports: [CommonModule, SvgViewerModule, MatCardModule, RouterModule],
+  imports: [CommonModule, SvgViewerModule, MatCardModule, RouterModule, NavigationFocusModule],
   exports: [ComponentList],
   declarations: [ComponentList],
   providers: [DocumentationItems],

--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -82,13 +82,14 @@ export class ComponentSidenav implements OnInit, OnDestroy {
     this.params = combineLatest(
         this._route.pathFromRoot.map(route => route.params), Object.assign);
 
-    this._navigationFocusService.navigationEndEvents.pipe(map(() => this.isScreenSmall))
+    this.subscriptions.add(
+      this._navigationFocusService.navigationEndEvents.pipe(map(() => this.isScreenSmall))
       .subscribe((shouldCloseSideNav) => {
           if (shouldCloseSideNav && this.sidenav) {
             this.sidenav.close();
           }
         }
-      );
+      ));
   }
 
   ngOnDestroy() {

--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -15,7 +15,7 @@ import {ActivatedRoute, Params, Router, RouterModule, Routes} from '@angular/rou
 import {CommonModule} from '@angular/common';
 import {ComponentHeaderModule} from '../component-page-header/component-page-header';
 import {FooterModule} from '../../shared/footer/footer';
-import {combineLatest, Observable, Subject} from 'rxjs';
+import {combineLatest, Observable, Subject, Subscription} from 'rxjs';
 import {map, startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 import {CdkAccordionModule} from '@angular/cdk/accordion';
@@ -58,11 +58,12 @@ const SMALL_WIDTH_BREAKPOINT = 959;
   styleUrls: ['./component-sidenav.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class ComponentSidenav implements OnInit {
+export class ComponentSidenav implements OnInit, OnDestroy {
   @ViewChild(MatSidenav) sidenav: MatSidenav;
   params: Observable<Params>;
   isExtraScreenSmall: Observable<boolean>;
   isScreenSmall: Observable<boolean>;
+  private subscriptions = new Subscription();
 
   constructor(public docItems: DocumentationItems,
               private _route: ActivatedRoute,
@@ -88,6 +89,10 @@ export class ComponentSidenav implements OnInit {
           }
         }
       );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 
   toggleSidenav(sidenav: MatSidenav): Promise<MatDrawerToggleResult> {

--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -11,12 +11,12 @@ import {
 import {DocumentationItems} from '../../shared/documentation-items/documentation-items';
 import {MatIconModule} from '@angular/material/icon';
 import {MatSidenav, MatSidenavModule} from '@angular/material/sidenav';
-import {ActivatedRoute, NavigationEnd, Params, Router, RouterModule, Routes} from '@angular/router';
+import {ActivatedRoute, Params, Router, RouterModule, Routes} from '@angular/router';
 import {CommonModule} from '@angular/common';
 import {ComponentHeaderModule} from '../component-page-header/component-page-header';
 import {FooterModule} from '../../shared/footer/footer';
 import {combineLatest, Observable, Subject} from 'rxjs';
-import {filter, map, startWith, switchMap, takeUntil} from 'rxjs/operators';
+import {map, startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {BreakpointObserver} from '@angular/cdk/layout';
@@ -40,6 +40,7 @@ import {SvgViewerModule} from '../../shared/svg-viewer/svg-viewer';
 import {MatDrawerToggleResult} from '@angular/material/sidenav/drawer';
 import {MatListModule} from '@angular/material/list';
 import {NavigationFocusModule} from '../../shared/navigation-focus/navigation-focus';
+import {NavigationFocusService} from '../../shared/navigation-focus/navigation-focus.service';
 
 // These constants are used by the ComponentSidenav for orchestrating the MatSidenav in a responsive
 // way. This includes hiding the sidenav, defaulting it to open, changing the mode from over to
@@ -65,7 +66,7 @@ export class ComponentSidenav implements OnInit {
 
   constructor(public docItems: DocumentationItems,
               private _route: ActivatedRoute,
-              private _router: Router,
+              private _navigationFocusService: NavigationFocusService,
               zone: NgZone,
               breakpoints: BreakpointObserver) {
     this.isExtraScreenSmall =
@@ -80,15 +81,13 @@ export class ComponentSidenav implements OnInit {
     this.params = combineLatest(
         this._route.pathFromRoot.map(route => route.params), Object.assign);
 
-    this._router.events.pipe(
-      filter((event) => event instanceof NavigationEnd),
-      map((event) => this.isScreenSmall)
-    ).subscribe((shouldCloseSideNav) => {
-        if (shouldCloseSideNav && this.sidenav) {
-          this.sidenav.close();
+    this._navigationFocusService.navigationEndEvents.pipe(map(() => this.isScreenSmall))
+      .subscribe((shouldCloseSideNav) => {
+          if (shouldCloseSideNav && this.sidenav) {
+            this.sidenav.close();
+          }
         }
-      }
-    );
+      );
   }
 
   toggleSidenav(sidenav: MatSidenav): Promise<MatDrawerToggleResult> {

--- a/src/app/pages/component-viewer/component-viewer.html
+++ b/src/app/pages/component-viewer/component-viewer.html
@@ -1,7 +1,7 @@
 <div class="docs-component-viewer">
   <nav mat-tab-nav-bar class="docs-component-viewer-tabbed-content"
        aria-label="Documentation Sections"
-       focusOnNavigation id="main-content" >
+       focusOnNavigation >
     <a mat-tab-link class="docs-component-viewer-section-tab"
         *ngFor="let section of sections"
         [routerLink]="section.toLowerCase()"

--- a/src/app/pages/component-viewer/component-viewer.html
+++ b/src/app/pages/component-viewer/component-viewer.html
@@ -1,7 +1,7 @@
 <div class="docs-component-viewer">
   <nav mat-tab-nav-bar class="docs-component-viewer-tabbed-content"
        aria-label="Documentation Sections"
-       id = "component-viewer"
+       id="component-viewer"
        focusOnNavigation >
     <a mat-tab-link class="docs-component-viewer-section-tab"
         *ngFor="let section of sections"

--- a/src/app/pages/component-viewer/component-viewer.html
+++ b/src/app/pages/component-viewer/component-viewer.html
@@ -1,6 +1,7 @@
 <div class="docs-component-viewer">
   <nav mat-tab-nav-bar class="docs-component-viewer-tabbed-content"
        aria-label="Documentation Sections"
+       id = "component-viewer"
        focusOnNavigation >
     <a mat-tab-link class="docs-component-viewer-section-tab"
         *ngFor="let section of sections"

--- a/src/app/pages/guide-list/guide-list.html
+++ b/src/app/pages/guide-list/guide-list.html
@@ -2,7 +2,7 @@
   <h1>Guides</h1>
 </header>
 
-<main focusOnNavigation id="main-content" aria-label="Guide list">
+<main focusOnNavigation aria-label="Guide list" id="guide-list">
   <mat-nav-list class="docs-guide-list">
     <a mat-list-item *ngFor="let guide of guideItems.getAllItems()"
         class="docs-guide-item"

--- a/src/app/pages/guide-viewer/guide-viewer.html
+++ b/src/app/pages/guide-viewer/guide-viewer.html
@@ -8,7 +8,7 @@
                 (contentRendered)="toc.addHeaders('Guide Content', $event); toc.updateScrollPosition()"
                 [documentUrl]="guide?.document"
                 focusOnNavigation
-                id="main-content" aria-label="Guide content"></doc-viewer>
+                aria-label="Guide content"></doc-viewer>
     <table-of-contents #toc container="guide-viewer"></table-of-contents>
   </div>
 </div>

--- a/src/app/pages/guide-viewer/guide-viewer.html
+++ b/src/app/pages/guide-viewer/guide-viewer.html
@@ -8,6 +8,7 @@
                 (contentRendered)="toc.addHeaders('Guide Content', $event); toc.updateScrollPosition()"
                 [documentUrl]="guide?.document"
                 focusOnNavigation
+                id="guide-content"
                 aria-label="Guide content"></doc-viewer>
     <table-of-contents #toc container="guide-viewer"></table-of-contents>
   </div>

--- a/src/app/pages/homepage/homepage.html
+++ b/src/app/pages/homepage/homepage.html
@@ -1,5 +1,5 @@
 <header focusOnNavigation class="docs-header-background"
-        [class.is-next-version]="isNextVersion" aria-label="Get started">
+        [class.is-next-version]="isNextVersion" aria-label="Get started" id="homepage-header">
   <div class="docs-header-section">
     <div class="docs-header-headline">
       <h1 class="mat-h1">Angular Material</h1>
@@ -16,7 +16,7 @@
     <div class="docs-homepage-promo-img">
       <docs-svg-viewer src="../assets/img/homepage/sprintzerotoapp.svg"
                        [scaleToContainer]="true"></docs-svg-viewer>
-    </div>
+    </div>s
     <div class="docs-homepage-promo-desc">
       <h2>Sprint from Zero to App</h2>
       <p>Hit the ground running with comprehensive, modern UI components that work across

--- a/src/app/pages/homepage/homepage.html
+++ b/src/app/pages/homepage/homepage.html
@@ -16,7 +16,7 @@
     <div class="docs-homepage-promo-img">
       <docs-svg-viewer src="../assets/img/homepage/sprintzerotoapp.svg"
                        [scaleToContainer]="true"></docs-svg-viewer>
-    </div>s
+    </div>
     <div class="docs-homepage-promo-desc">
       <h2>Sprint from Zero to App</h2>
       <p>Hit the ground running with comprehensive, modern UI components that work across

--- a/src/app/pages/homepage/homepage.html
+++ b/src/app/pages/homepage/homepage.html
@@ -1,5 +1,5 @@
 <header focusOnNavigation class="docs-header-background"
-        [class.is-next-version]="isNextVersion" id="main-content" aria-label="Get started">
+        [class.is-next-version]="isNextVersion" aria-label="Get started">
   <div class="docs-header-section">
     <div class="docs-header-headline">
       <h1 class="mat-h1">Angular Material</h1>

--- a/src/app/shared/navbar/navbar.html
+++ b/src/app/shared/navbar/navbar.html
@@ -1,7 +1,7 @@
 <!-- TODO: figure out if the <nav> should go inside of a <header> element. -->
 <nav class="docs-navbar-header" aria-label="Top Toolbar"
      [class.is-next-version]="isNextVersion">
-  <div class="skip-link-wrapper" [class.cdk-visually-hidden]="skipLinkHidden" >
+  <div class="skip-link-wrapper" [class.cdk-visually-hidden]="skipLinkHidden" *ngIf="skipLinkHref">
     <a mat-raised-button [href]="skipLinkHref" (focus)="skipLinkHidden = false" (blur)="skipLinkHidden = true" color="accent">
       Skip to main content
     </a>

--- a/src/app/shared/navbar/navbar.ts
+++ b/src/app/shared/navbar/navbar.ts
@@ -2,15 +2,15 @@ import {Component, NgModule, OnDestroy} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatMenuModule} from '@angular/material/menu';
-import {RouterModule, Event, NavigationEnd, Router} from '@angular/router';
+import {RouterModule} from '@angular/router';
 import {ThemePickerModule} from '../theme-picker';
 import {VersionPickerModule} from '../version-picker';
 import {SECTIONS} from '../documentation-items/documentation-items';
 import {ThemeStorage} from '../theme-picker/theme-storage/theme-storage';
 import {StyleManager} from '../style-manager';
 import {HttpClientModule} from '@angular/common/http';
-import {filter} from 'rxjs/operators';
 import {Subscription} from 'rxjs';
+import {NavigationFocusService} from '../navigation-focus/navigation-focus.service';
 
 const SECTIONS_KEYS = Object.keys(SECTIONS);
 
@@ -25,13 +25,8 @@ export class NavBar implements OnDestroy {
   skipLinkHref: string;
   skipLinkHidden = true;
 
-  constructor(router: Router) {
-    this.subscriptions.add(router.events
-      .pipe(filter((event: Event) => event instanceof NavigationEnd))
-      .subscribe(() => {
-        const baseUrl = router.url.split('#')[0];
-        this.skipLinkHref = `${baseUrl}#main-content`;
-      }));
+  constructor(private navigationFocusService: NavigationFocusService) {
+    setTimeout(() => this.skipLinkHref = this.navigationFocusService.getSkipLinkHref(), 100);
   }
 
   get sections() {

--- a/src/app/shared/navbar/navbar.ts
+++ b/src/app/shared/navbar/navbar.ts
@@ -22,7 +22,7 @@ const SECTIONS_KEYS = Object.keys(SECTIONS);
 export class NavBar implements OnDestroy {
   private subscriptions = new Subscription();
   isNextVersion = location.hostname.startsWith('next.material.angular.io');
-  skipLinkHref: string;
+  skipLinkHref: string|null;
   skipLinkHidden = true;
 
   constructor(private navigationFocusService: NavigationFocusService) {

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -43,7 +43,7 @@ export class NavigationFocusService implements OnDestroy {
   }
 
   requestSkipLinkFocus(el: ElementRef) {
-    this.navigationFocusRequests.push(el);
+    this.skipLinkFocusRequests.push(el);
     const baseUrl = this.router.url.split('#')[0];
     const skipLinKTargetId = el.nativeElement.id;
     this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
@@ -51,6 +51,12 @@ export class NavigationFocusService implements OnDestroy {
 
   relinquishSkipLinkFocusOnDestroy(el: ElementRef) {
     this.skipLinkFocusRequests.splice(this.skipLinkFocusRequests.indexOf(el), 1);
+    if (this.skipLinkFocusRequests.length) {
+      const skipLinkFocusTarget = this.skipLinkFocusRequests[this.skipLinkFocusRequests.length - 1];
+      const baseUrl = this.router.url.split('#')[0];
+      const skipLinKTargetId = skipLinkFocusTarget.nativeElement.id;
+      this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
+    }
   }
 
   getSkipLinkHref(): string {

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -34,20 +34,23 @@ export class NavigationFocusService implements OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  requestFocusOnNavigation(el: ElementRef, wantsFocus: boolean) {
-    wantsFocus ? this.navigationFocusRequests.push(el) :
-      this.navigationFocusRequests.splice(this.navigationFocusRequests.indexOf(el), 1);
+  requestFocusOnNavigation(el: ElementRef) {
+    this.navigationFocusRequests.push(el);
   }
 
-  requestSkipLinkFocus(el: ElementRef, wantsFocus: boolean) {
-    if (wantsFocus) {
-      this.navigationFocusRequests.push(el);
-      const baseUrl = this.router.url.split('#')[0];
-      const skipLinKTargetId = el.nativeElement.id;
-      this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
-    } else {
-      this.skipLinkFocusRequests.splice(this.skipLinkFocusRequests.indexOf(el), 1);
-    }
+  relinquishFocusOnDestroy(el: ElementRef) {
+    this.navigationFocusRequests.splice(this.navigationFocusRequests.indexOf(el), 1);
+  }
+
+  requestSkipLinkFocus(el: ElementRef) {
+    this.navigationFocusRequests.push(el);
+    const baseUrl = this.router.url.split('#')[0];
+    const skipLinKTargetId = el.nativeElement.id;
+    this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
+  }
+
+  relinquishSkipLinkFocusOnDestroy(el: ElementRef) {
+    this.skipLinkFocusRequests.splice(this.skipLinkFocusRequests.indexOf(el), 1);
   }
 
   getSkipLinkHref(): string {

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -1,0 +1,31 @@
+import {ElementRef, Injectable} from '@angular/core';
+import {Event, NavigationEnd, Router} from '@angular/router';
+import {filter, skip, take} from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NavigationFocusService {
+  private internalNavigation: boolean;
+  private focusRequestStack: ElementRef[];
+
+  constructor(private router:Router) {
+    this.router.events
+      .pipe(filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd),
+        skip(1),
+        take(1)
+      )
+      .subscribe(() => {
+        this.internalNavigation = true;
+      });
+  }
+
+  isInternalNavigation(): boolean {
+    return this.internalNavigation;
+  }
+
+  requestFocusOnNavigation(el: ElementRef, wantsFocus: boolean) {
+    wantsFocus ? this.focusRequestStack.push(el) :
+      this.focusRequestStack.splice(this.focusRequestStack.indexOf(el), 1);
+  }
+}

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -7,12 +7,21 @@ import {filter, skip, take} from 'rxjs/operators';
 })
 export class NavigationFocusService {
   private navigationFocusRequests: ElementRef[] = [];
+  private skipLinkFocusRequests: ElementRef[] = [];
 
-  constructor(private router:Router) {
+  constructor(private router: Router) {
     this.router.events
-      .pipe(filter(event  => event instanceof NavigationEnd),
-        skip(1),
-      )
+      .pipe(filter(event => event instanceof NavigationEnd),
+        take(1))
+      .subscribe(() => {
+        setTimeout(() =>
+          this.skipLinkFocusRequests[this.skipLinkFocusRequests.length - 1].nativeElement.id =
+            'main-content', 100);
+      });
+
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd),
+        skip(1))
       .subscribe(() => {
         if (!window.location.hash) {
           setTimeout(() =>
@@ -25,5 +34,10 @@ export class NavigationFocusService {
   requestFocusOnNavigation(el: ElementRef, wantsFocus: boolean) {
     wantsFocus ? this.navigationFocusRequests.push(el) :
       this.navigationFocusRequests.splice(this.navigationFocusRequests.indexOf(el), 1);
+  }
+
+  requestSkipLinkFocus(el: ElementRef, wantsFocus: boolean) {
+    wantsFocus ? this.skipLinkFocusRequests.push(el) :
+      this.skipLinkFocusRequests.splice(this.skipLinkFocusRequests.indexOf(el), 1);
   }
 }

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -1,31 +1,29 @@
 import {ElementRef, Injectable} from '@angular/core';
-import {Event, NavigationEnd, Router} from '@angular/router';
+import {NavigationEnd, Router} from '@angular/router';
 import {filter, skip, take} from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
 })
 export class NavigationFocusService {
-  private internalNavigation: boolean;
-  private focusRequestStack: ElementRef[];
+  private navigationFocusRequests: ElementRef[] = [];
 
   constructor(private router:Router) {
     this.router.events
-      .pipe(filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd),
+      .pipe(filter(event  => event instanceof NavigationEnd),
         skip(1),
-        take(1)
       )
       .subscribe(() => {
-        this.internalNavigation = true;
+        if (!window.location.hash) {
+          setTimeout(() =>
+            this.navigationFocusRequests[this.navigationFocusRequests.length - 1]
+              .nativeElement.focus({preventScroll: true}), 100);
+        }
       });
   }
 
-  isInternalNavigation(): boolean {
-    return this.internalNavigation;
-  }
-
   requestFocusOnNavigation(el: ElementRef, wantsFocus: boolean) {
-    wantsFocus ? this.focusRequestStack.push(el) :
-      this.focusRequestStack.splice(this.focusRequestStack.indexOf(el), 1);
+    wantsFocus ? this.navigationFocusRequests.push(el) :
+      this.navigationFocusRequests.splice(this.navigationFocusRequests.indexOf(el), 1);
   }
 }

--- a/src/app/shared/navigation-focus/navigation-focus.service.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.service.ts
@@ -1,29 +1,37 @@
-import {ElementRef, Injectable} from '@angular/core';
-import {NavigationEnd, Router} from '@angular/router';
+import {ElementRef, Injectable, OnDestroy} from '@angular/core';
+import {Event, NavigationEnd, Router} from '@angular/router';
 import {filter, skip} from 'rxjs/operators';
+import {Subscription} from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
-export class NavigationFocusService {
+export class NavigationFocusService implements OnDestroy {
+  private subscriptions = new Subscription();
   private navigationFocusRequests: ElementRef[] = [];
+  private skipLinkFocusRequests: ElementRef[] = [];
   private skipLinkHref = '';
 
-  readonly navigationEndEvents = this.router.events.pipe(filter(event => event instanceof
-    NavigationEnd));
+  readonly navigationEndEvents = this.router.events
+    .pipe(filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd));
   readonly softNavigations = this.navigationEndEvents.pipe(skip(1));
 
   constructor(private router: Router) {
-    this.softNavigations.subscribe(() => {
+    this.subscriptions.add(this.softNavigations.subscribe(() => {
       // focus if url does not have fragment
       if (!this.router.url.split('#')[1]) {
         setTimeout(() => {
           if (this.navigationFocusRequests.length) {
             this.navigationFocusRequests[this.navigationFocusRequests.length - 1]
               .nativeElement.focus({preventScroll: true});
-          }}, 100);
+          }
+        }, 100);
       }
-    });
+    }));
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 
   requestFocusOnNavigation(el: ElementRef, wantsFocus: boolean) {
@@ -31,13 +39,29 @@ export class NavigationFocusService {
       this.navigationFocusRequests.splice(this.navigationFocusRequests.indexOf(el), 1);
   }
 
-  requestSkipLinkFocus(el: ElementRef) {
-    const baseUrl = this.router.url.split('#')[0];
-    const skipLinKTargetId = el.nativeElement.id;
-    this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
+  requestSkipLinkFocus(el: ElementRef, wantsFocus: boolean) {
+    if (wantsFocus) {
+      this.navigationFocusRequests.push(el);
+      const baseUrl = this.router.url.split('#')[0];
+      const skipLinKTargetId = el.nativeElement.id;
+      this.skipLinkHref = `${baseUrl}#${skipLinKTargetId}`;
+    } else {
+      this.skipLinkFocusRequests.splice(this.skipLinkFocusRequests.indexOf(el), 1);
+    }
   }
 
   getSkipLinkHref(): string {
     return this.skipLinkHref;
+  }
+
+  isNavigationWithinComponentView(previousUrl: string, newUrl: string) {
+    const componentViewExpression = /(components|cdk)\/([^\/]+)/;
+
+    const previousUrlMatch = previousUrl.match(componentViewExpression);
+    const newUrlMatch = newUrl.match(componentViewExpression);
+
+    return previousUrl && newUrl && previousUrlMatch && newUrlMatch
+      && previousUrlMatch[0] === newUrlMatch[0]
+      && previousUrlMatch[1] === newUrlMatch[1];
   }
 }

--- a/src/app/shared/navigation-focus/navigation-focus.spec.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.spec.ts
@@ -24,10 +24,10 @@ describe('Navigation focus service', () => {
   }));
 
   it('should set skip link href', () => {
-    const div = document.createElement("div");
+    const div = document.createElement('div');
     div.id = 'skip-link-target';
     const element = new ElementRef(div);
-    navigationFocusService.requestSkipLinkFocus(element);
+    navigationFocusService.requestSkipLinkFocus(element, true);
     expect(navigationFocusService.getSkipLinkHref()).toBe('/#skip-link-target');
   });
 });

--- a/src/app/shared/navigation-focus/navigation-focus.spec.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.spec.ts
@@ -15,7 +15,7 @@ describe('Navigation focus service', () => {
         imports: [RouterTestingModule],
         providers: [NavigationFocusService]
       });
-      router = TestBed.get(Router);
+      router = TestBed.inject(Router);
     }
   );
 
@@ -27,7 +27,19 @@ describe('Navigation focus service', () => {
     const div = document.createElement('div');
     div.id = 'skip-link-target';
     const element = new ElementRef(div);
-    navigationFocusService.requestSkipLinkFocus(element, true);
+    navigationFocusService.requestSkipLinkFocus(element);
     expect(navigationFocusService.getSkipLinkHref()).toBe('/#skip-link-target');
   });
+
+  it('should be within component view', () => {
+    const previousUrl = '/components/autocomplete/overview';
+    const newUrl = '/components/autocomplete/overview#simple-autocomplete';
+    expect(navigationFocusService.isNavigationWithinComponentView(previousUrl, newUrl)).toBeTrue();
+  })
+
+  it('should not be within component view', () => {
+    const previousUrl = '/cdk/clipboard/overview';
+    const newUrl = '/cdk/categories';
+    expect(navigationFocusService.isNavigationWithinComponentView(previousUrl, newUrl)).toBeFalse();
+  })
 });

--- a/src/app/shared/navigation-focus/navigation-focus.spec.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.spec.ts
@@ -1,76 +1,142 @@
-import {async, inject, TestBed} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {Component, NgModule, NgZone} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Router} from '@angular/router';
-
-import {MATERIAL_DOCS_ROUTES} from '../../routes';
+import {RouterTestingModule} from '@angular/router/testing';
 import {NavigationFocusService} from './navigation-focus.service';
-import {ElementRef} from '@angular/core';
-
+import {NavigationFocusModule} from './navigation-focus';
 
 describe('Navigation focus service', () => {
   let navigationFocusService: NavigationFocusService;
   let router: Router;
+  let zone: NgZone;
+  let fixture: ComponentFixture<NavigationFocusTest>;
+
+  const navigate = (url: string) => {
+    zone.run(() => router.navigateByUrl(url));
+    tick(100);
+  };
 
   beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule.withRoutes(MATERIAL_DOCS_ROUTES)],
-        providers: [NavigationFocusService]
+        imports: [RouterTestingModule.withRoutes([
+          {path: '', component: RouteTest},
+          {path: 'cdk', component: RouteTest},
+          {path: 'guides', component: RouteTest}
+        ]),
+        NavigationFocusModule],
+        providers: [NavigationFocusService],
+        declarations: [NavigationFocusTest, RouteTest],
       });
-      router = TestBed.inject(Router);
+      fixture = TestBed.createComponent(NavigationFocusTest);
     }
   );
 
-  beforeEach(inject([NavigationFocusService], (nfs: NavigationFocusService) => {
-    navigationFocusService = nfs;
-  }));
+  beforeEach(() => {
+    zone = TestBed.inject(NgZone);
+    router = TestBed.inject(Router);
+    navigationFocusService = TestBed.inject(NavigationFocusService);
+  });
 
   it('should set skip link href', () => {
-    const div1 = document.createElement('div');
-    div1.id = 'skip-link-target-1';
-    const element1 = new ElementRef(div1);
+    const target1 = fixture.nativeElement.querySelector('#target1');
+    const target2 = fixture.nativeElement.querySelector('#target2');
 
-    const div2 = document.createElement('div');
-    div2.id = 'skip-link-target-2';
-    const element2 = new ElementRef(div2);
+    navigationFocusService.requestSkipLinkFocus(target1);
+    navigationFocusService.requestSkipLinkFocus(target2);
 
-    navigationFocusService.requestSkipLinkFocus(element1);
-    navigationFocusService.requestSkipLinkFocus(element2);
+    expect(navigationFocusService.getSkipLinkHref()).toEqual('/#target2');
 
-    expect(navigationFocusService.getSkipLinkHref()).toEqual('/#skip-link-target-2');
+    navigationFocusService.relinquishSkipLinkFocus(target2);
 
-    navigationFocusService.relinquishSkipLinkFocusOnDestroy(element2);
+    expect(navigationFocusService.getSkipLinkHref()).toEqual('/#target1');
+  });
 
-    expect(navigationFocusService.getSkipLinkHref()).toEqual('/#skip-link-target-1');
+  it('should set skip link href to null when there are no more requests', () => {
+    const target1 = fixture.nativeElement.querySelector('#target1');
+    const target3 = fixture.nativeElement.querySelector('.no-id');
+
+    navigationFocusService.requestSkipLinkFocus(target1);
+    expect(navigationFocusService.getSkipLinkHref()).toEqual('/#target1');
+
+    navigationFocusService.relinquishSkipLinkFocus(target1);
+    // target3 has `focusOnNavigation` directive that automatically requests focus, so focus must
+    // be relinquished to test the desired behaviour
+    navigationFocusService.relinquishSkipLinkFocus(target3);
+    expect(navigationFocusService.getSkipLinkHref()).toBeNull();
+  });
+
+  it('should set id for skip link target without id', () => {
+    const skipLinkTarget = fixture.nativeElement.querySelector('.no-id');
+
+    navigationFocusService.requestSkipLinkFocus(skipLinkTarget);
+
+    expect(navigationFocusService.getSkipLinkHref()).toMatch(`/#skip-link-target-[0-9]*`);
   });
 
   it('should be within component view', () => {
     const previousUrl = '/components/autocomplete/overview';
     const newUrl = '/components/autocomplete/overview#simple-autocomplete';
     expect(navigationFocusService.isNavigationWithinComponentView(previousUrl, newUrl)).toBeTrue();
-  })
+  });
 
   it('should not be within component view', () => {
     const previousUrl = '/cdk/clipboard/overview';
     const newUrl = '/cdk/categories';
     expect(navigationFocusService.isNavigationWithinComponentView(previousUrl, newUrl)).toBeFalse();
-  })
+  });
 
-  it('should focus on component then relinquish focus', async(async () => {
-    const div = document.createElement('div');
-    div.id = 'focus-target';
-    const element = new ElementRef(div);
+  it('should focus on component then relinquish focus', fakeAsync(() => {
+    const target1 = fixture.nativeElement.querySelector('#target1');
+    const target2 = fixture.nativeElement.querySelector('#target2');
 
-    navigationFocusService.requestFocusOnNavigation(element);
+    // First navigation event doesn't trigger focus because it represents a hardnav.
+    navigationFocusService.requestFocusOnNavigation(target1);
+    navigationFocusService.requestFocusOnNavigation(target2);
+    navigate('/');
+    expect(document.activeElement).not.toEqual(target1);
+    expect(document.activeElement).not.toEqual(target2);
 
-    await router.navigateByUrl('/');
-    expect(document.activeElement).not.toEqual(element.nativeElement);
+    // Most recent requester gets focus on the next nav.
+    navigate('/guides');
+    expect(document.activeElement).toEqual(target2);
 
-    await router.navigateByUrl('/guides');
-    expect(document.activeElement).toEqual(element.nativeElement);
+    // Falls back to the focusing the previous requester once the most recent one relinquishes.
+    navigationFocusService.relinquishFocusOnNavigation(target2);
+    navigate('/cdk');
+    expect(document.activeElement).toEqual(target1);
+  }));
 
-    navigationFocusService.relinquishFocusOnDestroy(element);
+  it('should not set focus when navigating to hash target', fakeAsync(() => {
+    const target1 = fixture.nativeElement.querySelector('#target1');
 
-    await router.navigateByUrl('/cdk');
-    expect(document.activeElement).not.toEqual(element.nativeElement);
-  }))
+    // First navigation event doesn't trigger focus because it represents a hardnav.
+    navigationFocusService.requestFocusOnNavigation(target1);
+    navigate('/');
+    expect(document.activeElement).not.toEqual(target1);
+
+    // Navigating to a hash target should not set focus on target1 even though it requested focus
+    navigate('/guides#hash');
+    expect(document.activeElement).not.toEqual(target1);
+  }));
 });
+
+@Component({
+  selector: 'navigation-focus-test',
+  template: `
+    <button id="target1">Target 1</button>
+    <button id="target2">Target 2</button>
+    <button class="no-id" focusOnNavigation>Target 3</button>
+  `
+})
+class NavigationFocusTest {
+}
+@NgModule({
+  imports: [NavigationFocusModule]
+})
+
+@Component({
+  selector: 'route-test',
+  template: '',
+})
+class RouteTest {
+}

--- a/src/app/shared/navigation-focus/navigation-focus.spec.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.spec.ts
@@ -1,0 +1,33 @@
+import {inject, TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Router} from '@angular/router';
+
+import {NavigationFocusService} from './navigation-focus.service';
+import {ElementRef} from '@angular/core';
+
+
+describe('Navigation focus service', () => {
+  let navigationFocusService: NavigationFocusService;
+  let router: Router;
+
+  beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        providers: [NavigationFocusService]
+      });
+      router = TestBed.get(Router);
+    }
+  );
+
+  beforeEach(inject([NavigationFocusService], (nfs: NavigationFocusService) => {
+    navigationFocusService = nfs;
+  }));
+
+  it('should set skip link href', () => {
+    const div = document.createElement("div");
+    div.id = 'skip-link-target';
+    const element = new ElementRef(div);
+    navigationFocusService.requestSkipLinkFocus(element);
+    expect(navigationFocusService.getSkipLinkHref()).toBe('/#skip-link-target');
+  });
+});

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -6,13 +6,15 @@ import {NavigationFocusService} from './navigation-focus.service';
 })
 export class NavigationFocus implements OnDestroy {
   @HostBinding('tabindex') role = '-1';
-
+  
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
     this.navigationFocusService.requestFocusOnNavigation(el, true);
+    this.navigationFocusService.requestSkipLinkFocus(el, true);
   }
 
   ngOnDestroy() {
     this.navigationFocusService.requestFocusOnNavigation(this.el, false);
+    this.navigationFocusService.requestSkipLinkFocus(this.el, false);
   }
 }
 

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -1,6 +1,7 @@
 import {NgModule, Directive, ElementRef, HostBinding, OnDestroy} from '@angular/core';
 import {NavigationFocusService} from './navigation-focus.service';
 
+let uid = 0;
 @Directive({
   selector: '[focusOnNavigation]',
 })
@@ -9,19 +10,18 @@ export class NavigationFocus implements OnDestroy {
   @HostBinding('style.outline') readonly outline = 'none';
 
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
-    if (!this.el.nativeElement.id) {
-      this.el.nativeElement.id = 'skip-link-target-${uid++}';
+    if (!el.nativeElement.id) {
+      el.nativeElement.id = `skip-link-target-${uid++}`;
     }
-    this.navigationFocusService.requestFocusOnNavigation(el);
-    this.navigationFocusService.requestSkipLinkFocus(el);
+    this.navigationFocusService.requestFocusOnNavigation(el.nativeElement);
+    this.navigationFocusService.requestSkipLinkFocus(el.nativeElement);
   }
 
   ngOnDestroy() {
-    this.navigationFocusService.relinquishFocusOnDestroy(this.el);
-    this.navigationFocusService.relinquishSkipLinkFocusOnDestroy(this.el);
+    this.navigationFocusService.relinquishFocusOnNavigation(this.el.nativeElement);
+    this.navigationFocusService.relinquishSkipLinkFocus(this.el.nativeElement);
   }
 }
-let uid = 0;
 @NgModule({
   declarations: [NavigationFocus],
   exports: [NavigationFocus],

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -5,21 +5,20 @@ import {NavigationFocusService} from './navigation-focus.service';
   selector: '[focusOnNavigation]',
 })
 export class NavigationFocus implements OnDestroy {
-  @HostBinding('tabindex') tabindex = '-1';
-  @HostBinding('style.outline') outline = 'none';
+  @HostBinding('tabindex') readonly tabindex = '-1';
+  @HostBinding('style.outline') readonly outline = 'none';
 
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
     if (!this.el.nativeElement.id) {
       this.el.nativeElement.id = this.el.nativeElement.className + '-focus-target';
     }
-    this.navigationFocusService.requestFocusOnNavigation(el, true);
-    this.navigationFocusService.requestSkipLinkFocus(el, true);
+    this.navigationFocusService.requestFocusOnNavigation(el);
+    this.navigationFocusService.requestSkipLinkFocus(el);
   }
 
   ngOnDestroy() {
-    this.navigationFocusService.requestFocusOnNavigation(this.el, false);
-    this.navigationFocusService.requestSkipLinkFocus(this.el, false);
-
+    this.navigationFocusService.relinquishFocusOnDestroy(this.el);
+    this.navigationFocusService.relinquishSkipLinkFocusOnDestroy(this.el);
   }
 }
 

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -6,15 +6,15 @@ import {NavigationFocusService} from './navigation-focus.service';
 })
 export class NavigationFocus implements OnDestroy {
   @HostBinding('tabindex') role = '-1';
-  
+  @HostBinding('style.outline') outline = 'none';
+
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
     this.navigationFocusService.requestFocusOnNavigation(el, true);
-    this.navigationFocusService.requestSkipLinkFocus(el, true);
+    this.navigationFocusService.requestSkipLinkFocus(el);
   }
 
   ngOnDestroy() {
     this.navigationFocusService.requestFocusOnNavigation(this.el, false);
-    this.navigationFocusService.requestSkipLinkFocus(this.el, false);
   }
 }
 

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -1,11 +1,5 @@
 import {NgModule, Directive, ElementRef, HostBinding, OnDestroy} from '@angular/core';
-import {Event, Router, NavigationEnd} from '@angular/router';
-import {filter} from 'rxjs/operators';
-import {Subscription} from 'rxjs';
 import {NavigationFocusService} from './navigation-focus.service';
-
-/** The timeout id of the previous focus change. */
-let lastTimeoutId = -1;
 
 @Directive({
   selector: '[focusOnNavigation]',
@@ -13,43 +7,13 @@ let lastTimeoutId = -1;
 export class NavigationFocus implements OnDestroy {
   @HostBinding('tabindex') role = '-1';
 
-  private subscriptions = new Subscription();
-
-  constructor(private el: ElementRef, private router: Router, private navigationFocusService: NavigationFocusService) {
-    if (this.navigationFocusService.isInternalNavigation()) {
-      clearTimeout(lastTimeoutId);
-      lastTimeoutId =
-        window.setTimeout(() => this.el.nativeElement.focus({preventScroll: true}), 100);
-      this.navigationFocusService.requestFocusOnNavigation(this.el, true);
-    }
-    // We need to subscribe in the constructor in order to catch the `NavigationEnd` event
-    // from navigating from the previous page to this page.
-    // this.subscriptions.add(
-    //   this.router.events
-    //     .pipe(
-    //       filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd))
-    //     .subscribe((navigationEnd: NavigationEnd) => {
-    //       const currentLocation = new URL(window.location.href);
-    //       if (!currentLocation.hash && isSoftNav(navigationEnd)) {
-    //         clearTimeout(lastTimeoutId);
-    //         lastTimeoutId =
-    //           window.setTimeout(() => this.el.nativeElement.focus({preventScroll: true}), 100);
-    //       }
-    //     }));
+  constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
+    this.navigationFocusService.requestFocusOnNavigation(el, true);
   }
 
   ngOnDestroy() {
     this.navigationFocusService.requestFocusOnNavigation(this.el, false);
-    this.subscriptions.unsubscribe();
   }
-}
-
-function isSoftNav(navigationEnd: NavigationEnd) {
-  // Each navigation has a unique id that is available on the RouterEvents. The id is a number that
-  // is incremented. This currently works in all cases because there is only 1 redirect in the app
-  // (`CanActivateComponentSidenav`) and it would not matter for that case. However it is worth
-  // nothing that this implementation "could" break if more guards/redirects are added.
-  return navigationEnd.id !== 1;
 }
 
 @NgModule({

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -5,16 +5,21 @@ import {NavigationFocusService} from './navigation-focus.service';
   selector: '[focusOnNavigation]',
 })
 export class NavigationFocus implements OnDestroy {
-  @HostBinding('tabindex') role = '-1';
+  @HostBinding('tabindex') tabindex = '-1';
   @HostBinding('style.outline') outline = 'none';
 
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
+    if (!this.el.nativeElement.id) {
+      this.el.nativeElement.id = this.el.nativeElement.className + '-focus-target';
+    }
     this.navigationFocusService.requestFocusOnNavigation(el, true);
-    this.navigationFocusService.requestSkipLinkFocus(el);
+    this.navigationFocusService.requestSkipLinkFocus(el, true);
   }
 
   ngOnDestroy() {
     this.navigationFocusService.requestFocusOnNavigation(this.el, false);
+    this.navigationFocusService.requestSkipLinkFocus(this.el, false);
+
   }
 }
 

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -10,7 +10,7 @@ export class NavigationFocus implements OnDestroy {
 
   constructor(private el: ElementRef, private navigationFocusService: NavigationFocusService) {
     if (!this.el.nativeElement.id) {
-      this.el.nativeElement.id = this.el.nativeElement.className + '-focus-target';
+      this.el.nativeElement.id = 'skip-link-target-${uid++}';
     }
     this.navigationFocusService.requestFocusOnNavigation(el);
     this.navigationFocusService.requestSkipLinkFocus(el);
@@ -21,7 +21,7 @@ export class NavigationFocus implements OnDestroy {
     this.navigationFocusService.relinquishSkipLinkFocusOnDestroy(this.el);
   }
 }
-
+let uid = 0;
 @NgModule({
   declarations: [NavigationFocus],
   exports: [NavigationFocus],

--- a/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/src/app/shared/navigation-focus/navigation-focus.ts
@@ -2,6 +2,7 @@ import {NgModule, Directive, ElementRef, HostBinding, OnDestroy} from '@angular/
 import {Event, Router, NavigationEnd} from '@angular/router';
 import {filter} from 'rxjs/operators';
 import {Subscription} from 'rxjs';
+import {NavigationFocusService} from './navigation-focus.service';
 
 /** The timeout id of the previous focus change. */
 let lastTimeoutId = -1;
@@ -14,24 +15,31 @@ export class NavigationFocus implements OnDestroy {
 
   private subscriptions = new Subscription();
 
-  constructor(private el: ElementRef, private router: Router) {
+  constructor(private el: ElementRef, private router: Router, private navigationFocusService: NavigationFocusService) {
+    if (this.navigationFocusService.isInternalNavigation()) {
+      clearTimeout(lastTimeoutId);
+      lastTimeoutId =
+        window.setTimeout(() => this.el.nativeElement.focus({preventScroll: true}), 100);
+      this.navigationFocusService.requestFocusOnNavigation(this.el, true);
+    }
     // We need to subscribe in the constructor in order to catch the `NavigationEnd` event
     // from navigating from the previous page to this page.
-    this.subscriptions.add(
-      this.router.events
-        .pipe(
-          filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd))
-        .subscribe((navigationEnd: NavigationEnd) => {
-          const currentLocation = new URL(window.location.href);
-          if (!currentLocation.hash && isSoftNav(navigationEnd)) {
-            clearTimeout(lastTimeoutId);
-            lastTimeoutId =
-              window.setTimeout(() => this.el.nativeElement.focus({preventScroll: true}), 100);
-          }
-        }));
+    // this.subscriptions.add(
+    //   this.router.events
+    //     .pipe(
+    //       filter((event: Event): event is NavigationEnd => event instanceof NavigationEnd))
+    //     .subscribe((navigationEnd: NavigationEnd) => {
+    //       const currentLocation = new URL(window.location.href);
+    //       if (!currentLocation.hash && isSoftNav(navigationEnd)) {
+    //         clearTimeout(lastTimeoutId);
+    //         lastTimeoutId =
+    //           window.setTimeout(() => this.el.nativeElement.focus({preventScroll: true}), 100);
+    //       }
+    //     }));
   }
 
   ngOnDestroy() {
+    this.navigationFocusService.requestFocusOnNavigation(this.el, false);
     this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -3,8 +3,8 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ActivatedRoute, Router} from '@angular/router';
-import {Subject, fromEvent} from 'rxjs';
-import {debounceTime, takeUntil} from 'rxjs/operators';
+import {fromEvent, Subscription} from 'rxjs';
+import {debounceTime} from 'rxjs/operators';
 import {NavigationFocusService} from '../navigation-focus/navigation-focus.service';
 
 interface LinkSection {
@@ -42,8 +42,8 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
 
   _rootUrl = this._router.url.split('#')[0];
   private _scrollContainer: any;
-  private _destroyed = new Subject();
   private _urlFragment = '';
+  private subscriptions = new Subscription();
 
   constructor(private _router: Router,
               private _route: ActivatedRoute,
@@ -51,22 +51,22 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
               private _navigationFocusService: NavigationFocusService,
               @Inject(DOCUMENT) private _document: Document) {
 
-    this._navigationFocusService.navigationEndEvents.pipe(takeUntil(this._destroyed))
+    this.subscriptions.add(this._navigationFocusService.navigationEndEvents
       .subscribe(() => {
         const rootUrl = _router.url.split('#')[0];
         if (rootUrl !== this._rootUrl) {
           this._rootUrl = rootUrl;
         }
-      });
+      }));
 
-    this._route.fragment.pipe(takeUntil(this._destroyed)).subscribe(fragment => {
+    this.subscriptions.add(this._route.fragment.subscribe(fragment => {
       this._urlFragment = fragment;
 
       const target = document.getElementById(this._urlFragment);
       if (target) {
         target.scrollIntoView();
       }
-    });
+    }));
   }
 
   ngOnInit(): void {
@@ -77,10 +77,9 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
         this._document.querySelectorAll(this.container)[0] : window;
 
       if (this._scrollContainer) {
-        fromEvent(this._scrollContainer, 'scroll').pipe(
-            takeUntil(this._destroyed),
+        this.subscriptions.add(fromEvent(this._scrollContainer, 'scroll').pipe(
             debounceTime(10))
-            .subscribe(() => this.onScroll());
+            .subscribe(() => this.onScroll()));
       }
     });
   }
@@ -90,7 +89,7 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._destroyed.next();
+    this.subscriptions.unsubscribe();
   }
 
   updateScrollPosition(): void {

--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -2,9 +2,10 @@ import {
   AfterViewInit, Component, ElementRef, Inject, Input, OnDestroy, OnInit
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {Subject, fromEvent} from 'rxjs';
 import {debounceTime, takeUntil} from 'rxjs/operators';
+import {NavigationFocusService} from '../navigation-focus/navigation-focus.service';
 
 interface LinkSection {
   name: string;
@@ -47,16 +48,16 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   constructor(private _router: Router,
               private _route: ActivatedRoute,
               private _element: ElementRef,
+              private _navigationFocusService: NavigationFocusService,
               @Inject(DOCUMENT) private _document: Document) {
 
-    this._router.events.pipe(takeUntil(this._destroyed)).subscribe((event) => {
-      if (event instanceof NavigationEnd) {
+    this._navigationFocusService.navigationEndEvents.pipe(takeUntil(this._destroyed))
+      .subscribe(() => {
         const rootUrl = _router.url.split('#')[0];
         if (rootUrl !== this._rootUrl) {
           this._rootUrl = rootUrl;
         }
-      }
-    });
+      });
 
     this._route.fragment.pipe(takeUntil(this._destroyed)).subscribe(fragment => {
       this._urlFragment = fragment;


### PR DESCRIPTION
Currently there are several places in the app try to track navigation events and properly redirect focus. The current approach is rather brittle, it would be better to coordinate it through a globally available service.

This service can manage:
- Allowing directives to request that the skip link jump to them
- Deciding which element will actually receive focus from the skip link
- Differentiating between hard and soft navigations