### PR TITLE
fix(stack-blitz): v7 demos fail when trying to load v9 dependencies

### DIFF
--- a/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -30,7 +30,7 @@ const TEMPLATE_FILES = [
 ];
 
 const TAGS: string[] = ['angular', 'material', 'example'];
-const angularVersion = '>=7.0.0';
+const angularVersion = '^7.0.0';
 
 const dependencies = {
   '@angular/cdk': materialVersion,


### PR DESCRIPTION
Fixes #748