### PR TITLE
Change stackblitz theme to indigo-pink

### DIFF
--- a/src/assets/stack-blitz/src/styles.scss
+++ b/src/assets/stack-blitz/src/styles.scss
@@ -1,4 +1,4 @@
-@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
+@import '~@angular/material/prebuilt-themes/indigo-pink.css';
 
 body {
   font-family: Roboto, Arial, sans-serif;


### PR DESCRIPTION
I don't remember why this was deeppurple-amber, but I think the StackBlitz theme should be the same as the default site theme.