### PR TITLE
enable compact view examples

### DIFF
--- a/src/app/pages/component-viewer/component-examples.html
+++ b/src/app/pages/component-viewer/component-examples.html
@@ -6,5 +6,5 @@
     *ngFor="let example of docItem?.examples"
     [example]="example"
     [showCompactToggle]="false"
-    [view]="'collapsed'"></example-viewer>
+    [view]="'demo'"></example-viewer>
 </ng-container>

--- a/src/app/shared/doc-viewer/doc-viewer.spec.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.spec.ts
@@ -71,9 +71,9 @@ describe('DocViewer', () => {
     expect(docViewer.nativeElement.innerHTML).toContain('id="my-header"');
   });
 
-  it('should instantiate example viewer in compact view with region', () => {
+  it('should instantiate example viewer in snippet view with region', () => {
     const fixture = TestBed.createComponent(DocViewerTestComponent);
-    const testUrl = 'http://material.angular.io/compact-example.html';
+    const testUrl = 'http://material.angular.io/snippet-example.html';
 
     fixture.componentInstance.documentUrl = testUrl;
     fixture.detectChanges();
@@ -87,9 +87,9 @@ describe('DocViewer', () => {
     expect(exampleViewer.componentInstance.view).toBe('snippet');
   });
 
-  it('should instantiate example viewer in collapsed view', () => {
+  it('should instantiate example viewer in demo view', () => {
     const fixture = TestBed.createComponent(DocViewerTestComponent);
-    const testUrl = 'http://material.angular.io/collapsed-example.html';
+    const testUrl = 'http://material.angular.io/demo-example.html';
 
     fixture.componentInstance.documentUrl = testUrl;
     fixture.detectChanges();
@@ -102,7 +102,7 @@ describe('DocViewer', () => {
     expect(exampleViewer.componentInstance.view).toBe('demo');
   });
 
-  it('should instantiate example viewer in compact view with whole snippet', () => {
+  it('should instantiate example viewer in snippet view with whole snippet', () => {
     const fixture = TestBed.createComponent(DocViewerTestComponent);
     const testUrl = 'http://material.angular.io/whole-snippet-example.html';
 
@@ -115,21 +115,6 @@ describe('DocViewer', () => {
     expect(exampleViewer.componentInstance.file).toBe('whole-snippet-example.ts');
     expect(exampleViewer.componentInstance.showCompactToggle).toBeTrue();
     expect(exampleViewer.componentInstance.view).toBe('snippet');
-  });
-
-  it('should instantiate example viewer in full view', () => {
-    const fixture = TestBed.createComponent(DocViewerTestComponent);
-    const testUrl = 'http://material.angular.io/expanded-example.html';
-
-    fixture.componentInstance.documentUrl = testUrl;
-    fixture.detectChanges();
-
-    http.expectOne(testUrl).flush(FAKE_DOCS[testUrl]);
-
-    const exampleViewer = fixture.debugElement.query(By.directive(ExampleViewer));
-    expect(exampleViewer.componentInstance.file).toBeUndefined();
-    expect(exampleViewer.componentInstance.showCompactToggle).toBeFalse();
-    expect(exampleViewer.componentInstance.view).toBe('full');
   });
 
   it('should show error message when doc not found', () => {
@@ -161,11 +146,10 @@ describe('DocViewer', () => {
 
 @Component({
   selector: 'test',
-  template: `<doc-viewer [documentUrl]="documentUrl" [lines]="lines"></doc-viewer>`,
+  template: `<doc-viewer [documentUrl]="documentUrl"></doc-viewer>`,
 })
 class DocViewerTestComponent {
   documentUrl = 'http://material.angular.io/simple-doc.html';
-  lines: [number, number];
 }
 
 const FAKE_DOCS: {[key: string]: string} = {
@@ -175,13 +159,11 @@ const FAKE_DOCS: {[key: string]: string} = {
       <div material-docs-example="some-example"></div>`,
   'http://material.angular.io/doc-with-links.html': `<a href="#test">Test link</a>`,
   'http://material.angular.io/doc-with-element-ids.html': `<h4 id="my-header">Header</h4>`,
-  'http://material.angular.io/compact-example.html':
+  'http://material.angular.io/snippet-example.html':
     '<div material-docs-example="some-example" file="some-example.html"' +
     ' region="some-region"></div>',
-  'http://material.angular.io/collapsed-example.html':
-    '<div material-docs-example="collapsed-example"></div>',
+  'http://material.angular.io/demo-example.html':
+    '<div material-docs-example="demo-example"></div>',
   'http://material.angular.io/whole-snippet-example.html':
     '<div material-docs-example="whole-snippet-example" file="whole-snippet-example.ts"></div>',
-  'http://material.angular.io/expanded-example.html':
-    '<div material-docs-example="expanded-snippet-example" expanded="true"></div>'
 };

--- a/src/app/shared/doc-viewer/doc-viewer.spec.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.spec.ts
@@ -5,6 +5,7 @@ import {By} from '@angular/platform-browser';
 import {DocsAppTestingModule} from '../../testing/testing-module';
 import {DocViewer} from './doc-viewer';
 import {DocViewerModule} from './doc-viewer-module';
+import {ExampleViewer} from '../example-viewer/example-viewer';
 
 
 describe('DocViewer', () => {
@@ -70,18 +71,65 @@ describe('DocViewer', () => {
     expect(docViewer.nativeElement.innerHTML).toContain('id="my-header"');
   });
 
-  it('should show part of example source code', () => {
+  it('should instantiate example viewer in compact view with region', () => {
     const fixture = TestBed.createComponent(DocViewerTestComponent);
-    const testUrl = 'http://material.angular.io/example-html.html';
+    const testUrl = 'http://material.angular.io/compact-example.html';
 
     fixture.componentInstance.documentUrl = testUrl;
-    fixture.componentInstance.lines = [0, 1];
     fixture.detectChanges();
 
     http.expectOne(testUrl).flush(FAKE_DOCS[testUrl]);
 
-    const docViewer = fixture.debugElement.query(By.directive(DocViewer));
-    expect(docViewer.componentInstance.textContent).toBe('line 1');
+    const exampleViewer = fixture.debugElement.query(By.directive(ExampleViewer));
+    expect(exampleViewer.componentInstance.file).toBe('some-example.html');
+    expect(exampleViewer.componentInstance.showCompactToggle).toBeTrue();
+    expect(exampleViewer.componentInstance.region).toBe('some-region');
+    expect(exampleViewer.componentInstance.view).toBe('snippet');
+  });
+
+  it('should instantiate example viewer in collapsed view', () => {
+    const fixture = TestBed.createComponent(DocViewerTestComponent);
+    const testUrl = 'http://material.angular.io/collapsed-example.html';
+
+    fixture.componentInstance.documentUrl = testUrl;
+    fixture.detectChanges();
+
+    http.expectOne(testUrl).flush(FAKE_DOCS[testUrl]);
+
+    const exampleViewer = fixture.debugElement.query(By.directive(ExampleViewer));
+    expect(exampleViewer.componentInstance.file).toBeUndefined();
+    expect(exampleViewer.componentInstance.showCompactToggle).toBeFalse();
+    expect(exampleViewer.componentInstance.view).toBe('demo');
+  });
+
+  it('should instantiate example viewer in compact view with whole snippet', () => {
+    const fixture = TestBed.createComponent(DocViewerTestComponent);
+    const testUrl = 'http://material.angular.io/whole-snippet-example.html';
+
+    fixture.componentInstance.documentUrl = testUrl;
+    fixture.detectChanges();
+
+    http.expectOne(testUrl).flush(FAKE_DOCS[testUrl]);
+
+    const exampleViewer = fixture.debugElement.query(By.directive(ExampleViewer));
+    expect(exampleViewer.componentInstance.file).toBe('whole-snippet-example.ts');
+    expect(exampleViewer.componentInstance.showCompactToggle).toBeTrue();
+    expect(exampleViewer.componentInstance.view).toBe('snippet');
+  });
+
+  it('should instantiate example viewer in full view', () => {
+    const fixture = TestBed.createComponent(DocViewerTestComponent);
+    const testUrl = 'http://material.angular.io/expanded-example.html';
+
+    fixture.componentInstance.documentUrl = testUrl;
+    fixture.detectChanges();
+
+    http.expectOne(testUrl).flush(FAKE_DOCS[testUrl]);
+
+    const exampleViewer = fixture.debugElement.query(By.directive(ExampleViewer));
+    expect(exampleViewer.componentInstance.file).toBeUndefined();
+    expect(exampleViewer.componentInstance.showCompactToggle).toBeFalse();
+    expect(exampleViewer.componentInstance.view).toBe('full');
   });
 
   it('should show error message when doc not found', () => {
@@ -127,8 +175,13 @@ const FAKE_DOCS: {[key: string]: string} = {
       <div material-docs-example="some-example"></div>`,
   'http://material.angular.io/doc-with-links.html': `<a href="#test">Test link</a>`,
   'http://material.angular.io/doc-with-element-ids.html': `<h4 id="my-header">Header</h4>`,
-  'http://material.angular.io/example-html.html':
-    `<span>line 1</span>
-     <span>line 2</span>
-     <span>line 3</span>`,
+  'http://material.angular.io/compact-example.html':
+    '<div material-docs-example="some-example" file="some-example.html"' +
+    ' region="some-region"></div>',
+  'http://material.angular.io/collapsed-example.html':
+    '<div material-docs-example="collapsed-example"></div>',
+  'http://material.angular.io/whole-snippet-example.html':
+    '<div material-docs-example="whole-snippet-example" file="whole-snippet-example.ts"></div>',
+  'http://material.angular.io/expanded-example.html':
+    '<div material-docs-example="expanded-snippet-example" expanded="true"></div>'
 };

--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -113,6 +113,8 @@ export class DocViewer implements OnDestroy {
 
     [...exampleElements].forEach((element: Element) => {
       const example = element.getAttribute(componentName);
+      const lines = element.getAttribute('lines');
+      const file = element.getAttribute('file');
       const portalHost = new DomPortalOutlet(
           element, this._componentFactoryResolver, this._appRef, this._injector);
       const examplePortal = new ComponentPortal(componentClass, this._viewContainerRef);
@@ -120,7 +122,14 @@ export class DocViewer implements OnDestroy {
       if (example !== null) {
         const exampleViewerComponent = exampleViewer.instance as ExampleViewer;
         exampleViewerComponent.example = example;
-        exampleViewerComponent.view = 'collapsed';
+        if (file) {
+          exampleViewerComponent.view = 'compact';
+          exampleViewerComponent.showCompactToggle = true;
+          exampleViewerComponent.file = file;
+        }
+        if (lines) {
+          exampleViewerComponent.lines = JSON.parse(lines);
+        }
       }
 
       this._portalHosts.push(portalHost);

--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -45,29 +45,25 @@ export class DocViewer implements OnDestroy {
 
   private static initExampleViewer(exampleViewerComponent: ExampleViewer,
                                    example: string,
-                                   expanded: string | null,
                                    file: string | null,
                                    region: string | null) {
     exampleViewerComponent.example = example;
-    if (expanded === 'true') {
-      exampleViewerComponent.view = 'full';
-    } else {
-      if (file) {
-        // if the html div has field `file` then it should be in compact view to show the code
-        // snippet
-        exampleViewerComponent.view = 'snippet';
-        exampleViewerComponent.showCompactToggle = true;
-        exampleViewerComponent.file = file;
-        if (region) {
-          // `lines` should only exist when `file` exists but not vice versa
-          // it is valid for embedded example snippets to show the whole file (esp short files)
-          exampleViewerComponent.region = region;
-        }
-      } else {
-        // otherwise it is an embedded demo
-        exampleViewerComponent.view = 'demo';
+    if (file) {
+      // if the html div has field `file` then it should be in compact view to show the code
+      // snippet
+      exampleViewerComponent.view = 'snippet';
+      exampleViewerComponent.showCompactToggle = true;
+      exampleViewerComponent.file = file;
+      if (region) {
+        // `region` should only exist when `file` exists but not vice versa
+        // It is valid for embedded example snippets to show the whole file (esp short files)
+        exampleViewerComponent.region = region;
       }
+    } else {
+      // otherwise it is an embedded demo
+      exampleViewerComponent.view = 'demo';
     }
+
   }
 
   constructor(private _appRef: ApplicationRef,
@@ -134,14 +130,13 @@ export class DocViewer implements OnDestroy {
       const example = element.getAttribute(componentName);
       const region = element.getAttribute('region');
       const file = element.getAttribute('file');
-      const expanded = element.getAttribute('expanded');
       const portalHost = new DomPortalOutlet(
           element, this._componentFactoryResolver, this._appRef, this._injector);
       const examplePortal = new ComponentPortal(componentClass, this._viewContainerRef);
       const exampleViewer = portalHost.attach(examplePortal);
       const exampleViewerComponent = exampleViewer.instance as ExampleViewer;
       if (example !== null) {
-        DocViewer.initExampleViewer(exampleViewerComponent, example, expanded, file, region);
+        DocViewer.initExampleViewer(exampleViewerComponent, example, file, region);
       }
       this._portalHosts.push(portalHost);
     });

--- a/src/app/shared/example-viewer/_example-viewer-theme.scss
+++ b/src/app/shared/example-viewer/_example-viewer-theme.scss
@@ -16,7 +16,7 @@
     }
 
     .docs-example-button {
-      color: mat-color($foreground, hint-text);
+      color: mat-color($foreground, secondary-text);
 
       [dir='rtl'] & {
         right: auto;

--- a/src/app/shared/example-viewer/code-snippet.html
+++ b/src/app/shared/example-viewer/code-snippet.html
@@ -1,3 +1,3 @@
 <div class="docs-example-source-wrapper">
-  <pre class="docs-example-source"><doc-viewer #viewer [documentUrl]="source" [lines]="lines"></doc-viewer></pre>
+  <pre class="docs-example-source"><doc-viewer #viewer [documentUrl]="source" ></doc-viewer></pre>
 </div>

--- a/src/app/shared/example-viewer/code-snippet.html
+++ b/src/app/shared/example-viewer/code-snippet.html
@@ -1,3 +1,3 @@
 <div class="docs-example-source-wrapper">
-  <pre class="docs-example-source"><doc-viewer #viewer [documentUrl]="source" ></doc-viewer></pre>
+  <pre class="docs-example-source"><doc-viewer #viewer [documentUrl]="source"></doc-viewer></pre>
 </div>

--- a/src/app/shared/example-viewer/code-snippet.ts
+++ b/src/app/shared/example-viewer/code-snippet.ts
@@ -1,4 +1,9 @@
-import {ChangeDetectionStrategy, Component, Input, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  ViewChild
+} from '@angular/core';
 import {DocViewer} from '../doc-viewer/doc-viewer';
 
 @Component({
@@ -9,6 +14,5 @@ import {DocViewer} from '../doc-viewer/doc-viewer';
 })
 export class CodeSnippet {
   @Input() source: string;
-  @Input() lines: readonly [number, number];
   @ViewChild('viewer') viewer: DocViewer;
 }

--- a/src/app/shared/example-viewer/example-viewer.html
+++ b/src/app/shared/example-viewer/example-viewer.html
@@ -1,5 +1,5 @@
 <div class="docs-example-viewer-wrapper">
-  <div class="docs-example-viewer-title" *ngIf="view !== 'compact'">
+  <div class="docs-example-viewer-title" *ngIf="view !== 'snippet'">
     <div class="docs-example-viewer-title-spacer">{{exampleData?.title}}</div>
 
     <button mat-icon-button type="button" (click)="toggleCompactView()" [matTooltip]="'View snippet only'"
@@ -13,7 +13,7 @@
     </button>
 
     <button mat-icon-button type="button" (click)="toggleSourceView()"
-            [matTooltip]="view==='collapsed' ? 'View code' : 'Hide code'" aria-label="View source">
+            [matTooltip]="view==='demo' ? 'View code' : 'Hide code'" aria-label="View source">
       <mat-icon>code</mat-icon>
     </button>
 
@@ -21,7 +21,7 @@
   </div>
 
   <div class="docs-example-viewer-source" *ngIf="view === 'full'">
-    <mat-tab-group animationDuration="0ms">
+    <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTab" (selectedIndexChange)="selectCorrectTab()">
       <mat-tab *ngFor="let tabName of _getExampleTabNames()" [label]="tabName">
         <div class="button-bar">
           <button mat-icon-button type="button" (click)="copySource(snippet.first.viewer.textContent)"
@@ -35,7 +35,7 @@
     </mat-tab-group>
   </div>
 
-  <div class="docs-example-viewer-source-compact" *ngIf="view === 'compact'">
+  <div class="docs-example-viewer-source-compact" *ngIf="view === 'snippet'">
     <div class="button-bar">
       <button mat-icon-button type="button" (click)="copySource(snippet.first.viewer.textContent)"
               class="docs-example-source-copy docs-example-button" [matTooltip]="'Copy snippet'"
@@ -52,10 +52,10 @@
         </mat-icon>
       </button>
     </div>
-    <code-snippet [source]="generateUrl(file)" [lines]="lines"></code-snippet>
+    <code-snippet [source]="fileUrl"></code-snippet>
   </div>
 
-  <div class="docs-example-viewer-body" *ngIf="view !== 'compact'">
+  <div class="docs-example-viewer-body" *ngIf="view !== 'snippet'">
     <ng-template *ngIf="_exampleComponentType && _exampleModuleFactory"
                  [ngComponentOutlet]="_exampleComponentType"
                  [ngComponentOutletNgModuleFactory]="_exampleModuleFactory"></ng-template>

--- a/src/app/shared/example-viewer/example-viewer.html
+++ b/src/app/shared/example-viewer/example-viewer.html
@@ -52,10 +52,10 @@
         </mat-icon>
       </button>
     </div>
-    <code-snippet [source]="file" [lines]="lines" *ngIf="file !== 'demo'"></code-snippet>
+    <code-snippet [source]="generateUrl(file)" [lines]="lines"></code-snippet>
   </div>
 
-  <div class="docs-example-viewer-body" *ngIf="view !== 'compact' || file === 'demo'">
+  <div class="docs-example-viewer-body" *ngIf="view !== 'compact'">
     <ng-template *ngIf="_exampleComponentType && _exampleModuleFactory"
                  [ngComponentOutlet]="_exampleComponentType"
                  [ngComponentOutletNgModuleFactory]="_exampleModuleFactory"></ng-template>

--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -16,6 +16,9 @@ import {CopierService} from '../copier/copier.service';
 import {DocViewerModule} from '../doc-viewer/doc-viewer-module';
 import {ExampleViewer} from './example-viewer';
 import {AutocompleteExamplesModule} from '@angular/components-examples/material/autocomplete';
+import {MatTabGroupHarness} from '@angular/material/tabs/testing';
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 
 const exampleKey = 'autocomplete-overview';
 const exampleBasePath = `/docs-content/examples-highlighted/material/autocomplete/${exampleKey}`;
@@ -25,6 +28,7 @@ describe('ExampleViewer', () => {
   let fixture: ComponentFixture<ExampleViewer>;
   let component: ExampleViewer;
   let http: HttpTestingController;
+  let loader: HarnessLoader;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -44,10 +48,11 @@ describe('ExampleViewer', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ExampleViewer);
     component = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
   it('should toggle between the 3 views', async(() => {
-    fixture.detectChanges();
     // need to specify a file because toggling from snippet to full changes the tabs to match
     component.file = 'file.html';
     component.view = 'snippet';
@@ -58,23 +63,40 @@ describe('ExampleViewer', () => {
     expect(component.view).toBe('demo');
   }));
 
-  it('should change to correct tab', async(() => {
-    fixture.detectChanges();
+  it('should expand to HTML tab', async(async () => {
+    component.example = exampleKey;
     component.file = 'file.html';
-    component.selectCorrectTab();
-    expect(component.selectedTab).toBe(0);
+    component.view = 'snippet';
+    component.toggleCompactView();
 
+    const tabGroup = await loader.getHarness(MatTabGroupHarness);
+    const tab = await tabGroup.getSelectedTab();
+    expect(await tab.getLabel()).toBe('HTML');
+  }));
+
+  it('should expand to TS tab', async(async () => {
+    component.example = exampleKey;
     component.file = 'file.ts';
-    component.selectCorrectTab();
-    expect(component.selectedTab).toBe(1);
+    component.view = 'snippet';
+    component.toggleCompactView();
 
+    const tabGroup = await loader.getHarness(MatTabGroupHarness);
+    const tab = await tabGroup.getSelectedTab();
+    expect(await tab.getLabel()).toBe('TS');
+  }));
+
+  it('should expand to CSS tab', async(async () => {
+    component.example = exampleKey;
     component.file = 'file.css';
-    component.selectCorrectTab();
-    expect(component.selectedTab).toBe(2);
+    component.view = 'snippet';
+    component.toggleCompactView();
+
+    const tabGroup = await loader.getHarness(MatTabGroupHarness);
+    const tab = await tabGroup.getSelectedTab();
+    expect(await tab.getLabel()).toBe('CSS');
   }));
 
   it('should generate correct url with region', async(() => {
-    fixture.detectChanges();
     component.example = exampleKey;
     component.region = 'region';
     const url = component.generateUrl('a.b.html');
@@ -82,7 +104,6 @@ describe('ExampleViewer', () => {
   }));
 
   it('should generate correct url without region', async(() => {
-    fixture.detectChanges();
     component.example = exampleKey;
     component.region = undefined;
     const url = component.generateUrl('a.b.ts');
@@ -91,19 +112,15 @@ describe('ExampleViewer', () => {
 
   it('should print an error message about incorrect file type', async(() => {
     spyOn(console, 'error');
-    fixture.detectChanges();
     component.file = 'file.bad';
     component.selectCorrectTab();
 
-
-    expect(console.error).toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(
       'Unexpected file type: bad. Expected html, ts, or css.');
   }));
 
   it('should set and return example properly', async(() => {
     component.example = exampleKey;
-    fixture.detectChanges();
     const data = component.exampleData;
     // TODO(jelbourn): remove `as any` once LiveExample is updated to have optional members.
     expect(data).toEqual(EXAMPLE_COMPONENTS[exampleKey] as any);
@@ -112,7 +129,6 @@ describe('ExampleViewer', () => {
   it('should print an error message about missing example', async(() => {
     spyOn(console, 'error');
     component.example = 'foobar';
-    fixture.detectChanges();
     expect(console.error).toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith('Could not find example: foobar');
   }));
@@ -120,7 +136,6 @@ describe('ExampleViewer', () => {
   it('should return docs-content path for example based on extension', async(() => {
     // set example
     component.example = exampleKey;
-    fixture.detectChanges();
 
     // get example file path for each extension
     const extensions = ['ts', 'css', 'html'];
@@ -137,7 +152,6 @@ describe('ExampleViewer', () => {
 
     it('should only render HTML, TS and CSS files if no additional files are specified', () => {
       component.example = exampleKey;
-      fixture.detectChanges();
 
       expect(component._getExampleTabNames()).toEqual(['HTML', 'TS', 'CSS']);
     });
@@ -149,7 +163,6 @@ describe('ExampleViewer', () => {
       };
 
       component.example = 'additional-files';
-      fixture.detectChanges();
 
       expect(component._getExampleTabNames())
         .toEqual(['HTML', 'TS', 'CSS', 'some-additional-file.html']);

--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -73,6 +73,34 @@ describe('ExampleViewer', () => {
     expect(component.selectedTab).toBe(2);
   }));
 
+  it('should generate correct url with region', async(() => {
+    fixture.detectChanges();
+    component.example = exampleKey;
+    component.region = 'region';
+    const url = component.generateUrl('a.b.html');
+    expect(url).toBe(exampleBasePath + '/a.b_region-html.html');
+  }));
+
+  it('should generate correct url without region', async(() => {
+    fixture.detectChanges();
+    component.example = exampleKey;
+    component.region = undefined;
+    const url = component.generateUrl('a.b.ts');
+    expect(url).toBe(exampleBasePath + '/a.b-ts.html');
+  }));
+
+  it('should print an error message about incorrect file type', async(() => {
+    spyOn(console, 'error');
+    fixture.detectChanges();
+    component.file = 'file.bad';
+    component.selectCorrectTab();
+
+
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      'Unexpected file type: bad. Expected html, ts, or css.');
+  }));
+
   it('should set and return example properly', async(() => {
     component.example = exampleKey;
     fixture.detectChanges();

--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -48,12 +48,29 @@ describe('ExampleViewer', () => {
 
   it('should toggle between the 3 views', async(() => {
     fixture.detectChanges();
-    component.view = 'compact';
-    expect(component.view).toBe('compact');
+    // need to specify a file because toggling from snippet to full changes the tabs to match
+    component.file = 'file.html';
+    component.view = 'snippet';
+    expect(component.view).toBe('snippet');
     component.toggleCompactView();
     expect(component.view).toBe('full');
     component.toggleSourceView();
-    expect(component.view).toBe('collapsed');
+    expect(component.view).toBe('demo');
+  }));
+
+  it('should change to correct tab', async(() => {
+    fixture.detectChanges();
+    component.file = 'file.html';
+    component.selectCorrectTab();
+    expect(component.selectedTab).toBe(0);
+
+    component.file = 'file.ts';
+    component.selectCorrectTab();
+    expect(component.selectedTab).toBe(1);
+
+    component.file = 'file.css';
+    component.selectCorrectTab();
+    expect(component.selectedTab).toBe(2);
   }));
 
   it('should set and return example properly', async(() => {

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -65,10 +65,10 @@ export class ExampleViewer implements OnInit {
   private _example: string;
 
   /** Range of lines of the source code to display in compact view. */
-  @Input() region: string;
+  @Input() region?: string;
 
   /** Name of file to display in compact view. */
-  @Input() file: string;
+  @Input() file?: string;
 
   constructor(private readonly snackbar: MatSnackBar, private readonly copier: CopierService) {
   }
@@ -80,13 +80,19 @@ export class ExampleViewer implements OnInit {
   }
 
   selectCorrectTab() {
-    const fileType = this.file.split('.')[1];
-    if (fileType === 'html') {
-      this.selectedTab = 0;
-    } else if (fileType === 'ts') {
-      this.selectedTab = 1;
-    } else if (fileType === 'css') {
-      this.selectedTab = 2;
+    const fileType = this.file?.split('.').slice(-1)[0];
+    switch (fileType) {
+      case 'html':
+        this.selectedTab = 0;
+        break;
+      case 'ts':
+        this.selectedTab = 1;
+        break;
+      case 'css':
+        this.selectedTab = 2;
+        break;
+      default:
+        console.error(`Unexpected file type: ${fileType}. Expected html, ts, or css.`);
     }
   }
 
@@ -113,11 +119,11 @@ export class ExampleViewer implements OnInit {
 
   generateUrl(file: string): string {
     let fileName: string;
-    if (this.region !== 'undefined') {
-      const fileSplit = file.split('.');
-      fileName = fileSplit[0] + '_' + this.region + '-' + fileSplit[1] + '.html';
+    const last = file.lastIndexOf('.');
+    if (this.region) {
+      fileName = file.substring(0, last) + '_' + this.region + '-' + file.substring(last + 1) + '.html';
     } else {
-      fileName = file.replace('.', '-') + '.html';
+      fileName = file.substring(0, last) + '-' + file.substring(last + 1) + '.html';
     }
 
     const examplePath = `${this.exampleData.module.importSpecifier}/${this.example}`;

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -83,6 +83,12 @@ export class ExampleViewer {
     }
   }
 
+  generateUrl(file: string): string {
+    const fileName = file.split('.').join('-') + '.html';
+    const examplePath = `${this.exampleData.module.importSpecifier}/${this.example}`;
+    return `/docs-content/examples-highlighted/${examplePath}/${fileName}`;
+  }
+
   _getExampleTabNames() {
     return Object.keys(this.exampleTabs);
   }


### PR DESCRIPTION
Extract fields from html generated from embedded example comments in md docs to generate compact view examples.

(extra: update button colours to be consistent)