### PR TITLE
center skip link

### DIFF
--- a/src/app/shared/navbar/navbar.scss
+++ b/src/app/shared/navbar/navbar.scss
@@ -43,7 +43,8 @@
 .skip-link-wrapper {
   position: absolute;
   top: 10px;
-  left: 44%;
+  left: 50%;
+  transform: translateX(-50%);
   border-radius: 5px;
 }
 


### PR DESCRIPTION
skip link was off centered 
`left: 44%` looked fine on most laptop screens but won't be centered on bigger/smaller screens