### PR TITLE
fix(component-category-list): links fail a11y contrast checks in dark mode

### DIFF
--- a/src/app/pages/component-category-list/_component-category-list-theme.scss
+++ b/src/app/pages/component-category-list/_component-category-list-theme.scss
@@ -8,7 +8,7 @@
   $nav-background-opacity: if($is-dark-theme, 0.2, 0.03);
 
   .docs-component-category-list-summary a {
-    color: mat-color($primary, default);
+    color: mat-color($primary, if($is-dark-theme, 200, default));
   }
 
   .docs-component-category-list-card-summary {


### PR DESCRIPTION
# Before
![Screen Shot 2020-06-24 at 19 40 32](https://user-images.githubusercontent.com/3506071/85638155-29ea8e80-b653-11ea-9f4d-d85ebb00613f.png)
![Screen Shot 2020-06-24 at 19 40 56](https://user-images.githubusercontent.com/3506071/85638158-2bb45200-b653-11ea-9e2d-6d602b146058.png)


# After
![Screen Shot 2020-06-24 at 19 40 14](https://user-images.githubusercontent.com/3506071/85638164-2e16ac00-b653-11ea-8929-bae534010f89.png)
![Screen Shot 2020-06-24 at 19 41 54](https://user-images.githubusercontent.com/3506071/85638168-2fe06f80-b653-11ea-8ecc-23fcc9b617f3.png)

