### PR TITLE
fix(guides): fix the positioning of the footer on the guides page

### DIFF
--- a/src/app/pages/guide-list/guide-list.html
+++ b/src/app/pages/guide-list/guide-list.html
@@ -2,7 +2,7 @@
   <h1>Guides</h1>
 </header>
 
-<main focusOnNavigation aria-label="Guide list" id="guide-list">
+<main focusOnNavigation aria-label="Guide list" id="guide-list" class="docs-guide">
   <mat-nav-list class="docs-guide-list">
     <a mat-list-item *ngFor="let guide of guideItems.getAllItems()"
         class="docs-guide-item"

--- a/src/app/pages/guide-list/guide-list.scss
+++ b/src/app/pages/guide-list/guide-list.scss
@@ -6,6 +6,10 @@
   flex-grow: 1;
 }
 
+.docs-guide {
+  min-height: 100%;
+}
+
 .docs-guide-list {
   flex-grow: 1;
   margin: $content-padding-side;

--- a/src/app/pages/guide-list/guide-list.spec.ts
+++ b/src/app/pages/guide-list/guide-list.spec.ts
@@ -27,4 +27,23 @@ describe('GuideList', () => {
       .length;
     expect(totalLinks).toEqual(totalItems);
   });
+
+  it('should set the footer below the bottom of the given view', () => {
+    const viewHeight = 1200;
+    const prevHeight = fixture.debugElement.styles['height'];
+    fixture.debugElement.styles['height'] = `${viewHeight}px`;
+    fixture.detectChanges();
+
+    const footer = fixture.nativeElement.querySelector('app-footer');
+    const main = fixture.nativeElement.querySelector('main');
+
+    expect(main.getBoundingClientRect().height)
+      .withContext('main content should take up the full given height')
+      .toBe(viewHeight);
+    expect(main.getBoundingClientRect().height + footer.getBoundingClientRect().height)
+      .withContext('footer should overflow allowed viewport')
+      .toBe(viewHeight + footer.getBoundingClientRect().height);
+
+    fixture.debugElement.styles['height'] = prevHeight;
+  });
 });


### PR DESCRIPTION
On the cdk and components pages the footer always displays below the bottom of the viewport whereas
on the guides page it displays in the middle of the page when viewed on larger devices. This fix
ensures that the guides page takes up 100% of the given viewport and the footer is displayed
outside the viewport matching the other pages.

----- 
example of current functionality 
![image](https://user-images.githubusercontent.com/12144493/85809115-dd6f8380-b724-11ea-8129-4e5d2b114562.png)
