### PR TITLE
update code snippet view

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
   <meta name="theme-color" content="#3f51b5">
 
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300,400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:400&display=swap" rel="stylesheet">
 
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
   <meta name="theme-color" content="#3f51b5">
 
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300,400&display=swap" rel="stylesheet">
 
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/styles/_markdown-theme.scss
+++ b/src/styles/_markdown-theme.scss
@@ -17,7 +17,7 @@
 
     pre {
       background: rgba(mat-color($foreground, secondary-text), .01);
-      border: .5px solid rgba(mat-color($foreground, secondary-text), .03);
+      border: .5px solid rgba(mat-color($foreground, secondary-text), .2);
 
       code {
         background: transparent;


### PR DESCRIPTION
Code snippets on the doc site use Roboto Mono with `font-weight: 300` this caused it to be hard to read on Windows.
![image](https://user-images.githubusercontent.com/20130030/86162132-2fb4f980-bac3-11ea-910c-769454fad6b8.png)

- add `font-weight: 400` for Roboto Mono
- change border around static snippets to visually separate them from surrounding text and to be consistent with live snippets

`font-weight: 400` without border change:
![image](https://user-images.githubusercontent.com/20130030/86162323-730f6800-bac3-11ea-8992-1668f75550c4.png)

`font-weight: 400` with border change:
![image](https://user-images.githubusercontent.com/20130030/86162352-815d8400-bac3-11ea-986e-aaa4a063432f.png)

dark mode:
![Screen Shot 2020-06-30 at 3 10 15 PM](https://user-images.githubusercontent.com/20130030/86181975-da3d1480-bae3-11ea-93f6-06f805a6a190.png)
