### PR TITLE
fix: homepage not using native accelerated scrolling on touch devices

### DIFF
--- a/src/app/material-docs-app.scss
+++ b/src/app/material-docs-app.scss
@@ -24,6 +24,7 @@ material-docs-app > app-homepage,
 material-docs-app > app-guides,
 material-docs-app > guide-viewer {
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
The home and guide pages are scrollable, but they felt janky because they didn't use the native accelerated scrolling.