### PR TITLE
fix: footer jumping up while guide is loading

### DIFF
--- a/src/app/pages/guide-viewer/guide-viewer.scss
+++ b/src/app/pages/guide-viewer/guide-viewer.scss
@@ -1,4 +1,4 @@
-@import "~@angular/material/theming";
+@import '~@angular/material/theming';
 @import '../../../styles/constants';
 
 /* For desktop, the content should be aligned with the page title. */
@@ -15,6 +15,10 @@ $guide-content-margin-side-xs: 15px;
   padding: 20px $content-padding-side 0;
   display: block;
   text-align: center;
+
+  // Ensures that the footer is pushed to the bottom and prevents
+  // the page from jumping around while something is loading.
+  min-height: 100vh;
 
   @media ($mat-xsmall) {
     padding-left: $content-padding-side-xs;


### PR DESCRIPTION
While a guide is loading we show a loading message and the page compresses down which causes the footer to show up for a split second. These changes add a style that always pushes the footer off the viewport.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/87722517-86574e80-c7b8-11ea-9981-2a4c4bbc9efc.gif)
