### PR TITLE
docs-bug(CDK:Overlay): Stackblitz example broken

### DIFF
--- a/src/assets/stack-blitz/src/app/material-module.ts
+++ b/src/assets/stack-blitz/src/app/material-module.ts
@@ -41,6 +41,7 @@ import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatTreeModule} from '@angular/material/tree';
+import {OverlayModule} from '@angular/cdk/overlay';
 
 @NgModule({
   exports: [
@@ -85,6 +86,7 @@ import {MatTreeModule} from '@angular/material/tree';
     MatToolbarModule,
     MatTooltipModule,
     MatTreeModule,
+    OverlayModule,
     PortalModule,
     ScrollingModule,
   ]


### PR DESCRIPTION
Add overlayModule import in material-module

Fixes https://github.com/angular/components/issues/19997