### PR TITLE
refactor: prepare for docs-content changes in v10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:content": "yarn upgrade @angular/components-examples",
     "build:sm": "ng build --prod --source-map",
     "prod-build": "ng build --prod",
-    "postinstall": "webdriver-manager update --gecko false && ngcc --async false --properties es2015 browser module main --first-only --create-ivy-entry-points",
+    "postinstall": "webdriver-manager update --gecko false",
     "publish-prod": "bash ./tools/deploy.sh stable prod",
     "publish-dev": "bash ./tools/deploy.sh",
     "publish-beta": "bash ./tools/deploy.sh stable beta"
@@ -30,7 +30,7 @@
     "@angular/cdk-experimental": "^10.0.2",
     "@angular/common": "^10.0.1",
     "@angular/compiler": "^10.0.1",
-    "@angular/components-examples": "angular/material2-docs-content#10.0.x",
+    "@angular/components-examples": "https://github.com/angular/material2-docs-content.git#33b7ab32041e2845fb82497ff304c86690fded90",
     "@angular/core": "^10.0.1",
     "@angular/forms": "^10.0.1",
     "@angular/google-maps": "^10.0.2",

--- a/src/app/shared/example-viewer/example-viewer.spec.ts
+++ b/src/app/shared/example-viewer/example-viewer.spec.ts
@@ -76,7 +76,7 @@ describe('ExampleViewer', () => {
 
   it('should expand to TS tab', async(async () => {
     component.example = exampleKey;
-    component.file = 'file.ts';
+    component.file = EXAMPLE_COMPONENTS[exampleKey].primaryFile;
     component.view = 'snippet';
     component.toggleCompactView();
 
@@ -112,18 +112,18 @@ describe('ExampleViewer', () => {
 
   it('should print an error message about incorrect file type', async(() => {
     spyOn(console, 'error');
+    component.example = exampleKey;
     component.file = 'file.bad';
     component.selectCorrectTab();
 
     expect(console.error).toHaveBeenCalledWith(
-      'Unexpected file type: bad. Expected html, ts, or css.');
+      `Could not find tab for file extension: "bad".`);
   }));
 
   it('should set and return example properly', async(() => {
     component.example = exampleKey;
     const data = component.exampleData;
-    // TODO(jelbourn): remove `as any` once LiveExample is updated to have optional members.
-    expect(data).toEqual(EXAMPLE_COMPONENTS[exampleKey] as any);
+    expect(data).toEqual(EXAMPLE_COMPONENTS[exampleKey]);
   }));
 
   it('should print an error message about missing example', async(() => {
@@ -159,13 +159,31 @@ describe('ExampleViewer', () => {
     it('should be able to render additional files', () => {
       EXAMPLE_COMPONENTS['additional-files'] = {
         ...EXAMPLE_COMPONENTS[exampleKey],
-        additionalFiles: ['some-additional-file.html'],
+        files: [
+          'additional-files-example.ts',
+          'additional-files-example.html',
+          'additional-files-example.css',
+          'some-additional-file.html'
+        ],
       };
 
       component.example = 'additional-files';
 
       expect(component._getExampleTabNames())
         .toEqual(['HTML', 'TS', 'CSS', 'some-additional-file.html']);
+    });
+
+    it('should be possible for example to not have CSS or HTML files', () => {
+      EXAMPLE_COMPONENTS['additional-files'] = {
+        ...EXAMPLE_COMPONENTS[exampleKey],
+        files: [
+          'additional-files-example.ts',
+        ],
+      };
+
+      component.example = 'additional-files';
+
+      expect(component._getExampleTabNames()).toEqual(['TS']);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,15 +202,9 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/components-examples@angular/material2-docs-content#10.0.x":
-  version "10.0.2-sha-ba5c2feb0"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/00da8d7f03897721fd841b7829f37a9afc06ed7f"
-  dependencies:
-    tslib "^2.0.0"
-
-"@angular/components-examples@https://github.com/angular/material2-docs-content.git#fd76eb77418b2193f243be0570b727e63728e3e3":
-  version "10.0.1-sha-55d50750e"
-  resolved "https://github.com/angular/material2-docs-content.git#fd76eb77418b2193f243be0570b727e63728e3e3"
+"@angular/components-examples@https://github.com/angular/material2-docs-content.git#33b7ab32041e2845fb82497ff304c86690fded90":
+  version "10.1.0-next.0-sha-57f20bfb9"
+  resolved "https://github.com/angular/material2-docs-content.git#33b7ab32041e2845fb82497ff304c86690fded90"
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
We recently refactored how our docs-content example module is composed.
We did this because the docs app assumes path in the docs-content
package that are not necessarily always correct. i.e. breaking the chips
drag and drop example.

Additionally the docs-content example module is now more self-contained
so that assumptions about files inside of an example are not required
anymore. i.e. examples can now _not_ have CSS or HTML files. Previously
we always had to display an empty CSS/HTML file (which is confusing).

See: https://github.com/angular/components/pull/20003