### PR TITLE
fix: footer not being pushed to the bottom of the page in guides

### DIFF
--- a/src/app/pages/guide-viewer/guide-viewer.scss
+++ b/src/app/pages/guide-viewer/guide-viewer.scss
@@ -16,10 +16,6 @@ $guide-content-margin-side-xs: 15px;
   display: block;
   text-align: center;
 
-  // Ensures that the footer is pushed to the bottom and prevents
-  // the page from jumping around while something is loading.
-  min-height: 100vh;
-
   @media ($mat-xsmall) {
     padding-left: $content-padding-side-xs;
     padding-right: $content-padding-side-xs;
@@ -33,6 +29,10 @@ $guide-content-margin-side-xs: 15px;
   text-align: left;
   max-width: 940px;
   margin: 0 auto;
+
+  // Ensures that the footer is pushed to the bottom and prevents
+  // the page from jumping around while something is loading.
+  min-height: 100vh;
 
   @media (max-width: $extra-small-breakpoint-width) {
     flex-direction: column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,12 +208,6 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/components-examples@https://github.com/angular/material2-docs-content.git#33b7ab32041e2845fb82497ff304c86690fded90":
-  version "10.1.0-next.0-sha-57f20bfb9"
-  resolved "https://github.com/angular/material2-docs-content.git#33b7ab32041e2845fb82497ff304c86690fded90"
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/core@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.0.1.tgz#7737de1e7e382034e86dcff32282af8c209a7787"


### PR DESCRIPTION
Fixes a regression caused by #834 which means that the footer stays in place right after the fold on the page, instead of being pushed to the bottom.

Fixes https://github.com/angular/components/issues/20049.