### PR TITLE
fix: remove extension from Stackblitz examples

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
@@ -29,6 +29,7 @@ describe('StackBlitzWriter', () => {
     data = new ExampleData('');
     data.componentNames = [];
     data.exampleFiles = ['test.ts', 'test.html', 'src/detail.ts'];
+    data.indexFilename = data.exampleFiles[0];
 
     // Fake the example in the `EXAMPLE_COMPONENTS`. The stack blitz writer relies on
     // module information for the example in order to read the example sources from disk.

--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -213,12 +213,14 @@ export class StackBlitzWriter {
       // Replace `bootstrap: [MaterialDocsExample]`
       // will be replaced as `bootstrap: [ButtonDemo]`
       // This assumes the first component listed in the main component
-      const componentList = data.componentNames[0];
       fileContent = fileContent.
         replace(/bootstrap: \[MaterialDocsExample]/g,
-          `bootstrap: [${componentList}]`);
+          `bootstrap: [${data.componentNames[0]}]`);
 
-      fileContent = fileContent.replace(/material-docs-example/g, data.indexFilename);
+      const dotIndex = data.indexFilename.lastIndexOf('.');
+      const importFileName = data.indexFilename.slice(0, dotIndex === -1 ? undefined : dotIndex);
+      fileContent = fileContent.replace(/material-docs-example/g, importFileName);
+
     }
     return fileContent;
   }


### PR DESCRIPTION
In https://github.com/angular/components/commit/d00cb12582ab1265d38bb0f3012b7bd1adced97f the docs generation script changed the `indexFilename` to include the file extension which ends up propagating to TS imports inside generated Stackblitz examples. These changes strip the extension.

Fixes https://github.com/angular/components/issues/20061.