### PR TITLE
docs(button): Exclude toggle button examples from button examples.

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -89,7 +89,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       summary: 'An interactive button with a range of presentation options.',
       exampleSpecs: {
         prefix: 'button-',
-        exclude: ['button-toggle-appearance', 'button-toggle-exclusive', 'button-toggle-overview']
+        exclude: ['button-toggle-']
       },
       additionalApiDocs: [{name: 'Testing', path: 'material-button-testing.html'}],
     },
@@ -511,7 +511,7 @@ for (const doc of DOCS[COMPONENTS]) {
   doc.examples =
     exampleNames
       .filter(key => key.match(RegExp(`^${doc.exampleSpecs.prefix}`)) &&
-        !doc.exampleSpecs.exclude?.includes(key));
+        !doc.exampleSpecs.exclude?.some(excludeName => key.indexOf(excludeName) === 0));
 }
 
 for (const doc of DOCS[CDK]) {

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -89,6 +89,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       summary: 'An interactive button with a range of presentation options.',
       exampleSpecs: {
         prefix: 'button-',
+        exclude: ['button-toggle-appearance', 'button-toggle-exclusive', 'button-toggle-overview']
       },
       additionalApiDocs: [{name: 'Testing', path: 'material-button-testing.html'}],
     },


### PR DESCRIPTION
* Examples are matched using the prefix specified in documentation-items.ts
* Button & button-toggle both start with 'button-' prefix, so examples are getting mixed.
* We will exclude certain examples using "exclude" property.