### PR TITLE
 Use `img` element in component list w/ lazy loading

### DIFF
--- a/src/app/pages/component-category-list/component-category-list.html
+++ b/src/app/pages/component-category-list/component-category-list.html
@@ -8,9 +8,13 @@
      class="docs-component-category-list-item"
     [routerLink]="'/' + section + '/' + component.id">
     <div class="docs-component-category-list-card">
-      <div *ngIf="section === 'components'" class="docs-component-category-list-card-image-wrapper"
-      [style.backgroundImage]="'url(../../../assets/screenshots/'+component.id+'.scene.png)'">
-      </div>
+      <img *ngIf="section === 'components'"
+          class="docs-component-category-list-card-image-wrapper"
+          [src]="'../../../assets/screenshots/' + component.id + '.scene.png'"
+          loading="lazy"
+          alt=""
+          role="presentation"
+          aria-hidden="true">
       <div class="docs-component-category-list-card-title">{{component.name}}</div>
       <div class="docs-component-category-list-card-summary">{{component.summary}}</div>
     </div>

--- a/src/app/pages/component-category-list/component-category-list.scss
+++ b/src/app/pages/component-category-list/component-category-list.scss
@@ -58,7 +58,6 @@
 
 .docs-component-category-list-card-image-wrapper {
   height: 156px;
-  background-size: cover;
 }
 
 .docs-component-category-list-card-summary {


### PR DESCRIPTION
Switch the component list to use the `img` element so we can take advantage of native lazy-loading.