### PR TITLE
fix: some testing entry points referring to wrong module

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -72,7 +72,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       exampleSpecs: {
         prefix: 'badge-',
       },
-      additionalApiDocs: [{name: 'Testing', path: 'material-button-toggle-testing.html'}],
+      additionalApiDocs: [{name: 'Testing', path: 'material-badge-testing.html'}],
     },
     {
       id: 'bottom-sheet',
@@ -100,6 +100,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       exampleSpecs: {
         prefix: 'button-toggle-',
       },
+      additionalApiDocs: [{name: 'Testing', path: 'material-button-toggle-testing.html'}],
     },
     {
       id: 'card',
@@ -222,7 +223,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       exampleSpecs: {
         prefix: 'paginator-',
       },
-      additionalApiDocs: [{name: 'Testing', path: 'material-autocomplete-testing.html'}],
+      additionalApiDocs: [{name: 'Testing', path: 'material-paginator-testing.html'}],
     },
     {
       id: 'progress-bar',
@@ -356,6 +357,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       exampleSpecs: {
         prefix: 'tooltip-',
       },
+      additionalApiDocs: [{name: 'Testing', path: 'material-tooltip-testing.html'}],
     },
     {
       id: 'tree',


### PR DESCRIPTION
Some of the testing entry points were referring to incorrect modules (e.g. badge was pointing to button toggle). These changes fix them and add some of the newer harnesses that aren't in the docs.

Fixes https://github.com/angular/components/issues/20260.