### PR TITLE
build: re-add ngcc postinstall for docs content

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:content": "yarn upgrade @angular/components-examples",
     "build:sm": "ng build --prod --source-map",
     "prod-build": "ng build --prod",
-    "postinstall": "webdriver-manager update --gecko false",
+    "postinstall": "webdriver-manager update --gecko false && ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
     "publish-prod": "bash ./tools/deploy.sh stable prod",
     "publish-dev": "bash ./tools/deploy.sh",
     "publish-beta": "bash ./tools/deploy.sh stable beta"


### PR DESCRIPTION
We recently removed the ngcc postinstall since the Angular
compiler webpack plugin dynamcially processed packages that
were imported. This reduced Yarn install time for the docs site.

Now due to a recent update of the CLI build-angular version,
the examples break because ngcc no longer processes entry-points
based on module dependencies, but rather only as per TypeScript
program source files/referenced files. This does not include the
docs-content as the examples are loaded lazily and aren't part of
the TS compilation.

Here is the related change in the CLI:

https://github.com/angular/angular-cli/commit/6670af2d3329959efb0e0831cf2105d9591d7475