### PR TITLE
build: fix angular cli commonjs warnings for polyfills

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,6 +20,7 @@
             "sourceMap": true,
             "outputPath": "dist/material-angular-io",
             "index": "src/index.html",
+            "polyfills": "src/polyfills.ts",
             "main": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
             "assets": [

--- a/src/assets/stack-blitz/src/main.ts
+++ b/src/assets/stack-blitz/src/main.ts
@@ -1,5 +1,3 @@
-import './polyfills';
-
 import {HttpClientModule} from '@angular/common/http';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,4 +16,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-import 'zone.js/fesm2015/zone-error';  // Included with Angular CLI.
+// import 'zone.js/fesm2015/zone-error';  // Included with Angular CLI.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,3 @@
-import './polyfills.ts';
-
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {enableProdMode} from '@angular/core';
 import {environment} from './environments/environment';


### PR DESCRIPTION
The polyfills file was incorrectly imported through the `main` file
of the CLI project. This caused undesired CommonJS dependency
warnings for ZoneJS. We fix this by removing the import of the
polyfills and letting the CLI handle the polyfills as normally done
in fresh CLI projects.

Also disables the zone-error import from the devmode environment.
ZoneJS generally has the potential of hiding errors (as seen with
the `Object.defineProperty` patch that was enabled by default in
non-evergreen Zone bundles), so we should disable it. It seems
better aligning devmode as much as possible with prodmode to catch
issues more quickly. Debugging without `zone-error` is not any
different from common Angular/ZoneJS errors as seen in the components
or framework repositories.