### PR TITLE
Updated Material component  anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The guides, examples, and docs content repo
 [angular/material2-docs-content](https://github.com/angular/material2-docs-content) contains the
 documentation content and examples. They are generated from:
 - [Angular Material and CDK Guides](https://github.com/angular/components/tree/master/guides)
-- [Material components, services, and directives](https://github.com/angular/components/tree/master/src/lib)
+- [Material components, services, and directives](https://github.com/angular/components/tree/master/src/material)
 - [CDK components, services, and directives](https://github.com/angular/components/tree/master/src/cdk)
 
 ## Development Setup


### PR DESCRIPTION
# Material components, services, and directives Link:

Issue #870  :
Anchor link was not valid inside readme section.
Solution:
Replaced that with official material directory