### PR TITLE
fix(toc): visibility on resizing

### DIFF
--- a/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.ts
@@ -68,7 +68,7 @@ export class DocViewer implements OnDestroy {
 
   constructor(private _appRef: ApplicationRef,
               private _componentFactoryResolver: ComponentFactoryResolver,
-              private _elementRef: ElementRef,
+              public _elementRef: ElementRef,
               private _http: HttpClient,
               private _injector: Injector,
               private _viewContainerRef: ViewContainerRef,


### PR DESCRIPTION
## Motivation

On the documentation page of a component, resizing down the width under 1200px makes the right sided table of contents disappears. By resizing the width to more than 1000px, the table of contents does not re-appear.

## Reproduction

Navigate to any component documentation from the [overview](https://material.angular.io/components/categories).
Resize the width to less than 1200px.
Resize it back to more than 1200px.

=> the table of contents isn't present.

## Changes

add change detection
trigger the event emitters to populate the toc

Closes [angular/components issue ](https://github.com/angular/components/issues/20315)

