### PR TITLE
refactor: remove duplicate module import

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -160,7 +160,6 @@ const routes: Routes = [ {
     HttpClientModule,
     CdkAccordionModule,
     MatIconModule,
-    MatSidenavModule,
     StackBlitzButtonModule,
     SvgViewerModule,
     RouterModule.forChild(routes),


### PR DESCRIPTION
Removes duplicate import of `MatSidenavModule` into `ComponentSidenavModule` (likely to have occurred during a merge conflict resolution somewhere between #697 & #698).