### PR TITLE
Docs titles clipped on the left side - anchors not accessible

### DIFF
--- a/src/app/pages/component-viewer/component-viewer.scss
+++ b/src/app/pages/component-viewer/component-viewer.scss
@@ -29,6 +29,7 @@ app-component-viewer {
   component-overview, component-api {
     display: flex;
     align-items: flex-start;
+    overflow: visible;
 
     @media (max-width: $small-breakpoint-width) {
       flex-direction: column;


### PR DESCRIPTION
Fixes the visibility of the anchor titles documentation UI which is currently clipped. This is done by assigning CSS `overflow: visible` property to the parent component - component-overview.

Fixes [20687](https://github.com/angular/components/issues/20687)

_**Before**_
![Screenshot 2020-11-22 at 4 54 14 AM](https://user-images.githubusercontent.com/7993862/99889936-066a5500-2c80-11eb-9ba0-f4bbd6f951b0.png)

_**After**_
![Screenshot 2020-11-22 at 4 54 47 AM](https://user-images.githubusercontent.com/7993862/99889947-1aae5200-2c80-11eb-8a30-4a689c6589fe.png)

The approach mentioned in [20687](https://github.com/angular/components/issues/20687) suggests removing the margin of -30px from `header-link`. This would make the header text start after 30px with nothing in between. The approach in this PR is taken to overcome this visual oddity.
