### PR TITLE
fix: include date range picker examples

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -134,7 +134,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       name: 'Datepicker',
       summary: 'Captures dates, agnostic about their internal representation.',
       exampleSpecs: {
-        prefix: 'datepicker-',
+        prefix: 'date',
       },
       additionalApiDocs: [{name: 'Testing', path: 'material-datepicker-testing.html'}],
     },


### PR DESCRIPTION
prefix `datepicker-` excludes date range picker examples