### PR TITLE
feat: add 404 page

### DIFF
--- a/src/_app-theme.scss
+++ b/src/_app-theme.scss
@@ -5,6 +5,7 @@
 @import './app/pages/component-viewer/component-viewer-theme';
 @import './app/pages/guide-list/guide-list-theme';
 @import './app/pages/homepage/homepage-theme';
+@import './app/pages/not-found/not-found-theme';
 @import './app/shared/carousel/carousel-theme';
 @import './app/shared/example-viewer/example-viewer-theme';
 @import './app/shared/footer/footer-theme';
@@ -56,6 +57,7 @@
   @include footer-theme($theme);
   @include guide-list-theme($theme);
   @include home-page-theme($theme);
+  @include not-found-theme($theme);
   @include nav-bar-theme($theme);
   @include table-of-contents-theme($theme);
 }

--- a/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/src/app/pages/component-sidenav/component-sidenav.ts
@@ -118,32 +118,31 @@ export class ComponentNav {
   constructor(public docItems: DocumentationItems) {}
 }
 
-const routes: Routes = [ {
-  path : '',
-  component : ComponentSidenav,
-  children : [
-    {path : '', redirectTo : 'categories', pathMatch : 'full'},
-    {path : 'component/:id', redirectTo : ':id', pathMatch : 'full'},
-    {path : 'category/:id', redirectTo : '/categories/:id', pathMatch : 'full'},
+const routes: Routes = [{
+  path: '',
+  component: ComponentSidenav,
+  children: [
+    {path: 'component/:id', redirectTo: ':id', pathMatch: 'full'},
+    {path: 'category/:id', redirectTo: '/categories/:id', pathMatch: 'full'},
     {
-      path : 'categories',
-      children : [
-        {path : '', component : ComponentCategoryList},
+      path: 'categories',
+      children: [
+        {path: '', component: ComponentCategoryList},
       ],
     },
     {
-      path : ':id',
-      component : ComponentViewer,
-      children : [
-        {path : '', redirectTo : 'overview', pathMatch : 'full'},
-        {path : 'overview', component : ComponentOverview, pathMatch : 'full'},
-        {path : 'api', component : ComponentApi, pathMatch : 'full'},
-        {path : 'examples', component : ComponentExamples, pathMatch : 'full'},
-        {path : '**', redirectTo : 'overview'},
+      path: ':id',
+      component: ComponentViewer,
+      children: [
+        {path: '', redirectTo: 'overview', pathMatch: 'full'},
+        {path: 'overview', component: ComponentOverview, pathMatch: 'full'},
+        {path: 'api', component: ComponentApi, pathMatch: 'full'},
+        {path: 'examples', component: ComponentExamples, pathMatch: 'full'}
       ],
     },
+    {path: '**', redirectTo: '/404'}
   ]
-} ];
+}];
 
 @NgModule({
   imports: [

--- a/src/app/pages/not-found/_not-found-theme.scss
+++ b/src/app/pages/not-found/_not-found-theme.scss
@@ -1,0 +1,27 @@
+@mixin not-found-theme($theme) {
+  $primary: map-get($theme, primary);
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  $frown-color: mat-color($background, background);
+  $shield-color: mat-color($primary);
+
+  app-not-found {
+    color: mat-color($foreground, text);
+
+    .shield-left {
+      fill: $shield-color;
+    }
+
+    .shield-right {
+      fill: darken($shield-color, 10%);
+    }
+
+    .eye {
+      fill: $frown-color;
+    }
+
+    .frown {
+      stroke: $frown-color;
+    }
+  }
+}

--- a/src/app/pages/not-found/index.ts
+++ b/src/app/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export * from './not-found';

--- a/src/app/pages/not-found/not-found.html
+++ b/src/app/pages/not-found/not-found.html
@@ -1,0 +1,30 @@
+<main>
+  <div class="wrapper">
+    <svg
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 200 200"
+      xml:space="preserve">
+    <path class="shield-left" d="M5.7,33.2L98.8,0l95.5,32.6l-15.4,123.1L98.8,200L20,156.3L5.7,33.2z"/>
+    <path class="shield-right" d="M194.3,32.6L98.8,0v200l80.1-44.3L194.3,32.6L194.3,32.6z"/>
+    <circle class="eye" cx="61.7" cy="80" r="10.7"/>
+    <circle class="eye" cx="138.3" cy="80" r="10.7"/>
+    <path
+      class="frown"
+      stroke-width="10"
+      stroke-linecap="round"
+      fill="none"
+      d="M138,130.6c0,0-33.5-42.5-76,0"/>
+    </svg>
+
+    <div>
+      <h1>Page Not Found</h1>
+      <p>We're sorry. The page you are looking for cannot be found.</p>
+      <a routerLink="/" mat-raised-button color="primary">Go Home</a>
+      <a routerLink="/guides" mat-raised-button>Read Guides</a>
+    </div>
+  </div>
+</main>
+
+<app-footer></app-footer>

--- a/src/app/pages/not-found/not-found.scss
+++ b/src/app/pages/not-found/not-found.scss
@@ -1,0 +1,37 @@
+$vertical-spacing: 64px;
+$horizontal-spacing: 32px;
+
+main {
+  min-height: 100vh;
+  font-size: 1.25rem;
+}
+
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: $vertical-spacing;
+}
+
+svg {
+  height: 300px;
+  max-width: 100%;
+  margin-right: $horizontal-spacing;
+}
+
+a + a {
+  margin-left: 16px;
+}
+
+@media (max-width: 720px) {
+  .wrapper {
+    flex-direction: column;
+  }
+
+  svg {
+    height: auto;
+    max-height: 300px;
+    margin-right: 0;
+    margin-bottom: $vertical-spacing;
+  }
+}

--- a/src/app/pages/not-found/not-found.ts
+++ b/src/app/pages/not-found/not-found.ts
@@ -1,0 +1,22 @@
+import {Component, NgModule} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+import {FooterModule} from '../../shared/footer/footer';
+import {RouterModule, Routes} from '@angular/router';
+
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.html',
+  styleUrls: ['./not-found.scss']
+})
+export class NotFound {
+}
+
+const routes: Routes = [{path: '', component: NotFound}];
+
+@NgModule({
+  imports: [MatButtonModule, FooterModule, RouterModule.forChild(routes)],
+  exports: [NotFound],
+  declarations: [NotFound]
+})
+export class NotFoundModule {
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -3,10 +3,13 @@ import {CanActivateComponentSidenav} from './pages/component-sidenav/component-s
 
 export const MATERIAL_DOCS_ROUTES: Routes = [
   {
-    path: '', pathMatch: 'full',
+    path: '',
+    pathMatch: 'full',
     loadChildren: () => import('./pages/homepage').then(m => m.HomepageModule)
   },
   {path: 'categories', redirectTo: '/components/categories'},
+  {path: 'cdk', pathMatch: 'full', redirectTo: '/cdk/categories'},
+  {path: 'components', pathMatch: 'full', redirectTo: '/components/categories'},
   {
     path: 'guides',
     loadChildren: () => import('./pages/guide-list').then(m => m.GuideListModule)
@@ -18,11 +21,16 @@ export const MATERIAL_DOCS_ROUTES: Routes = [
     path: 'guide/:id',
     loadChildren: () => import('./pages/guide-viewer').then(m => m.GuideViewerModule)
   },
+  // Needs to be defined before `:section` so it gets picked first when redirecting a missing page.
+  {
+    path: '404',
+    loadChildren: () => import('./pages/not-found').then(m => m.NotFoundModule)
+  },
   {
     path: ':section',
     canActivate: [CanActivateComponentSidenav],
     loadChildren: () =>
       import('./pages/component-sidenav/component-sidenav').then(m => m.ComponentSidenavModule)
   },
-  {path: '**', redirectTo: ''},
+  {path: '**', redirectTo: '/404'},
 ];


### PR DESCRIPTION
Sets up a dedicated 404 page, rather than redirecting everything to the front page which doesn't tell the user that their link is incorrect. The design is based on the one from angular.io.

I also had to make some adjustments to the routing setup, because everything was being picked up by the `:section` route and we didn't have defined routes for `/cdk` and `/components` to which we link from the top nav.

![Angular_Material_UI_component_library_-_Google_Chr_2021-01-04_18-07-41](https://user-images.githubusercontent.com/4450522/103555016-7d6a4e80-4eb8-11eb-8041-479112ef7992.png)
