### PR TITLE
fix(component-viewer): Loading document... getting wrapped

### DIFF
--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -4,22 +4,22 @@
   </span>
 
   <!--
-  The span container is necessary for the layout to display properly. When
+  This container is necessary for the layout to display properly. When
   a component has multiple API docs, they need to be joined together in the
   same container so that they display one after another.
   -->
-  <span>
+  <div class="docs-component-api">
     <doc-viewer [documentUrl]="getApiDocumentUrl(docItem!)"
-      class="docs-component-view-text-content docs-component-api"
+      class="docs-component-view-text-content"
       (contentRendered)="updateTableOfContents(docItem!.name, $event)">
     </doc-viewer>
 
     <doc-viewer *ngFor="let additionalApiDoc of docItem!.additionalApiDocs; let index = index"
       documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
-      class="docs-component-view-text-content docs-component-api"
+      class="docs-component-view-text-content"
       (contentRendered)="updateTableOfContents(additionalApiDoc.name, $event, index + 1)">
     </doc-viewer>
-  </span>
+  </div>
 
   <table-of-contents #toc
       *ngIf="showToc | async"

--- a/src/app/pages/component-viewer/component-viewer.scss
+++ b/src/app/pages/component-viewer/component-viewer.scss
@@ -59,7 +59,6 @@ app-component-viewer {
 .docs-component-api,
 .docs-component-overview {
   width: 80%;
-  display: inline-flex;
 
   @media (max-width: $small-breakpoint-width) {
     width: 100%;


### PR DESCRIPTION
- when there is plenty of room, the message is being wrapped due to the width
  of the new parent span that was added in #717

# Before

![Screen Shot 2021-01-29 at 14 36 15](https://user-images.githubusercontent.com/3506071/106319682-cc00d380-623f-11eb-9094-edb590ddbf00.png)


# After

![Screen Shot 2021-01-29 at 14 35 53](https://user-images.githubusercontent.com/3506071/106319688-ce632d80-623f-11eb-9c66-2ee782e59561.png)

Harness API docs aren't side-by-side
![Screen Shot 2021-01-29 at 14 58 40](https://user-images.githubusercontent.com/3506071/106321627-8abdf300-6242-11eb-936b-f2e79fec2532.png)
