### PR TITLE
feat: add CSP and recommended security headers to site

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,13 +8,79 @@
         "destination": "/index.html"
       }
     ],
-    "headers": [{
-      "source" : "/assets/versions.json",
-      "headers" : [{
-        "key" : "Access-Control-Allow-Origin",
-        "value" : "*"
-      }]
-    }],
+    "headers": [
+      {
+        "source": "/assets/versions.json",
+        "headers": [
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          }
+        ]
+      },
+      {
+        "source": "/**(*.@(css|js|json|html|svg))",
+        "headers": [
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          }
+        ]
+      },
+      {
+        "source": "/**",
+        "headers": [
+          {
+            "key": "X-XSS-Protection",
+            "value": "1"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Content-Security-Policy",
+            "value": "upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src *; frame-src https://www.youtube.com; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; child-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net https://api.github.com;"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=15811200, s-maxage=31536000"
+          }
+        ]
+      },
+      {
+        "source": "/*.svg",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000"
+          }
+        ]
+      },
+      {
+        "source": "/*.@(webmanifest|ico)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=604800, s-maxage=1209600"
+          }
+        ]
+      },
+      {
+        "source": "/*.@(js|css)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000"
+          }
+        ]
+      }
+    ],
     "ignore": [
       "firebase.json",
       "**/node_modules/**",

--- a/tools/audit-docs.js
+++ b/tools/audit-docs.js
@@ -32,7 +32,7 @@ const MIN_SCORES_PER_PAGE = [
     url: '',
     minScores: {
       'pwa': 70,
-      'performance': 20,
+      'performance': 30,
       'seo': 98,
       'best-practices': 100,
       'accessibility': 100


### PR DESCRIPTION
- update cache ages for different types of assets
  - assets 6 months, CDN 1 year
  - js/css that is hashed per build, 1 year
  - webmanifest/ico 7 days, CDN 14 days
  - CLI auto-inlined SVG in root dir 1 year

Relates to https://github.com/angular/angular/issues/37631

# Before

![Screen Shot 2021-01-29 at 15 57 26](https://user-images.githubusercontent.com/3506071/106326716-eb512e00-624a-11eb-88b3-2ef4a416735e.png)
![Screen Shot 2021-01-29 at 15 58 38](https://user-images.githubusercontent.com/3506071/106326720-ed1af180-624a-11eb-897b-505c09846938.png)
![Screen Shot 2021-01-29 at 16 01 13](https://user-images.githubusercontent.com/3506071/106326913-48e57a80-624b-11eb-892a-e7bd6db8eb1c.png)


# After

![Screen Shot 2021-01-29 at 15 58 17](https://user-images.githubusercontent.com/3506071/106326731-f015e200-624a-11eb-92e2-7c87ea5122ad.png)
![Screen Shot 2021-01-29 at 15 58 48](https://user-images.githubusercontent.com/3506071/106326734-f1dfa580-624a-11eb-9c40-1a622b61d148.png)
![Screen Shot 2021-01-29 at 16 02 43](https://user-images.githubusercontent.com/3506071/106327054-7df1cd00-624b-11eb-9db8-141c0d991d48.png)


You can test this out for yourself against https://angularmaterial.dev/ using
- https://securityheaders.com/
- https://webpagetest.org/