### PR TITLE
fix: add styling for markdown tables

### DIFF
--- a/src/styles/_markdown-theme.scss
+++ b/src/styles/_markdown-theme.scss
@@ -32,5 +32,11 @@
     code {
       background: rgba(mat-color($foreground, secondary-text), $exportBackgroundOpacity);
     }
+
+    > table {
+      th, td {
+        border-bottom-color: mat-color($foreground, divider);
+      }
+    }
   }
 }

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -35,10 +35,6 @@
     text-decoration: none;
   }
 
-  td code {
-    font-size: 14px;
-  }
-
   pre {
     border-radius: 5px;
     display: block;
@@ -55,6 +51,30 @@
 
   code {
     padding: 3px;
+  }
+
+  // Target direct descendants here so that the styles don't bleed into the live examples.
+  > table {
+    text-align: left;
+    table-layout: fixed;
+    border-collapse: collapse;
+    margin-bottom: 1em;
+    font-size: 14px;
+
+    tr {
+      height: 48px;
+    }
+
+    th, td {
+      padding: 8px 4px 8px 0;
+      border-bottom-width: 1px;
+      border-bottom-style: solid;
+    }
+
+    // Code tends to wrap inside tables which doesn't look great with the background color.
+    code {
+      background: transparent;
+    }
   }
 }
 


### PR DESCRIPTION
Adds some basic styles to clean up the appearance of the Markdown-generated tables.

**Before:**
![Drag_and_Drop__Angular_Material_-_Google_Chrome_2021-02-10_18-07-48](https://user-images.githubusercontent.com/4450522/107545179-4aa82a00-6bcb-11eb-934b-b8a2c83fcc60.png)

**After:**
![Drag_and_Drop__Angular_Material_-_Google_Chrome_2021-02-10_18-07-11](https://user-images.githubusercontent.com/4450522/107545196-50057480-6bcb-11eb-824f-202fe944f79b.png)
