### PR TITLE
fix: declare duplicate theming guide

### DIFF
--- a/src/app/shared/guide-items/guide-items.ts
+++ b/src/app/shared/guide-items/guide-items.ts
@@ -24,17 +24,17 @@ const GUIDES = [
     id: 'theming',
     name: 'Theming Angular Material',
     document: '/docs-content/guides/theming.html',
-    overview: `Customize your application with Angular Material's theming system.`
+    overview: 'Customize your application with Angular Material\'s theming system.'
   },
   {
     id: 'theming-your-components',
     name: 'Theming your own components',
     document: '/docs-content/guides/theming-your-components.html',
-    overview: `Use Angular Material's theming system in your own custom components.`
+    overview: 'Use Angular Material\'s theming system in your own custom components.'
   },
   {
     id: 'typography',
-    name: `Customizing Typography`,
+    name: 'Customizing Typography',
     document: '/docs-content/guides/typography.html',
     overview: 'Configure the typography settings for Angular Material components.'
   },
@@ -64,9 +64,15 @@ const GUIDES = [
   },
   {
     id: 'using-component-harnesses',
-    name: `Testing with component harnesses`,
+    name: 'Testing with component harnesses',
     document: '/docs-content/guides/using-component-harnesses.html',
     overview: 'Write tests with component harnesses for convenience and meaningful results.'
+  },
+  {
+    id: 'duplicate-theming-styles',
+    name: 'Duplicate theming styles',
+    document: '/docs-content/guides/duplicate-theming-styles.html',
+    overview: 'Learn about our new color mixins for Sass that avoid duplicating theming styles.'
   }
 ];
 


### PR DESCRIPTION
Fixes a 404 due to a guide not being declared.

Fixes https://github.com/angular/components/issues/21853.