### PR TITLE
fix: remove workarounds for async pipe type narrowing bug

### DIFF
--- a/src/app/pages/component-viewer/component-api.html
+++ b/src/app/pages/component-viewer/component-api.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
   <span class="cdk-visually-hidden" tabindex="-1">
-    API for {{docItem?.id}}
+    API for {{docItem.id}}
   </span>
 
   <!--
@@ -9,12 +9,12 @@
   same container so that they display one after another.
   -->
   <div class="docs-component-api">
-    <doc-viewer [documentUrl]="getApiDocumentUrl(docItem!)"
+    <doc-viewer [documentUrl]="getApiDocumentUrl(docItem)"
       class="docs-component-view-text-content"
-      (contentRendered)="updateTableOfContents(docItem!.name, $event)">
+      (contentRendered)="updateTableOfContents(docItem.name, $event)">
     </doc-viewer>
 
-    <doc-viewer *ngFor="let additionalApiDoc of docItem!.additionalApiDocs; let index = index"
+    <doc-viewer *ngFor="let additionalApiDoc of docItem.additionalApiDocs; let index = index"
       documentUrl="/docs-content/api-docs/{{additionalApiDoc.path}}"
       class="docs-component-view-text-content"
       (contentRendered)="updateTableOfContents(additionalApiDoc.name, $event, index + 1)">

--- a/src/app/pages/component-viewer/component-examples.html
+++ b/src/app/pages/component-viewer/component-examples.html
@@ -1,9 +1,9 @@
 <ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
   <span class="cdk-visually-hidden" tabindex="-1">
-    Examples for {{docItem?.id}}
+    Examples for {{docItem.id}}
   </span>
   <example-viewer
-    *ngFor="let example of docItem?.examples"
+    *ngFor="let example of docItem.examples"
     [example]="example"
     [showCompactToggle]="false"
     [view]="'demo'"></example-viewer>

--- a/src/app/pages/component-viewer/component-overview.html
+++ b/src/app/pages/component-viewer/component-overview.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="componentViewer.componentDocItem | async; let docItem">
   <h2 class="cdk-visually-hidden" tabindex="-1">
-    Overview for {{docItem?.id}}
+    Overview for {{docItem.id}}
   </h2>
-  <doc-viewer [documentUrl]="getOverviewDocumentUrl(docItem!)"
+  <doc-viewer [documentUrl]="getOverviewDocumentUrl(docItem)"
       class="docs-component-view-text-content docs-component-overview"
       (contentRendered)="updateTableOfContents('Overview Content', $event)">
   </doc-viewer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,8 +218,8 @@
     tslib "^2.0.0"
 
 "@angular/components-examples@angular/material2-docs-content#11.2.x":
-  version "11.2.1-sha-c3abc1415"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/f12afada83c15eb29b672b5dd8d64760ce2b2c2b"
+  version "11.2.2-sha-d2583706c"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/321bd6c32051098bf87e8d6adeb8c727a2578486"
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
- related bug that is now fixed: https://github.com/angular/angular/issues/34572
- related discussion: https://github.com/angular/material.angular.io/pull/689#issuecomment-567621892

Reverts https://github.com/angular/material.angular.io/commit/f813cc6d0c12bc52dab5237922403fcde4108e72.