### PR TITLE
build: update StackBlitz demos to typescript 4.2

### DIFF
--- a/src/assets/stack-blitz-tests/package.json
+++ b/src/assets/stack-blitz-tests/package.json
@@ -29,8 +29,8 @@
     "zone.js": "^0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.1200.0-next.4",
-    "@angular/cli": "^12.0.0-next.4",
+    "@angular-devkit/build-angular": "0.1200.0-next.5",
+    "@angular/cli": "^12.0.0-next.5",
     "@angular/compiler-cli": "^12.0.0-next.0",
     "@angular/language-service": "^12.0.0-next.0",
     "@angular/localize": "^12.0.0-next.0",
@@ -39,6 +39,6 @@
     "codelyzer": "^6.0.1",
     "ts-node": "^8.10.2",
     "tslint": "~6.1.2",
-    "typescript": "~4.1.5"
+    "typescript": "~4.2.3"
   }
 }

--- a/src/assets/stack-blitz/package.json
+++ b/src/assets/stack-blitz/package.json
@@ -29,8 +29,8 @@
     "zone.js": "^0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^0.1200.0-next.4",
-    "@angular/cli": "^12.0.0-next.4",
+    "@angular-devkit/build-angular": "^0.1200.0-next.5",
+    "@angular/cli": "^12.0.0-next.5",
     "@angular/compiler-cli": "^12.0.0-next.0",
     "@angular/language-service": "^12.0.0-next.0",
     "@angular/localize": "^12.0.0-next.0",
@@ -38,6 +38,6 @@
     "codelyzer": "^6.0.1",
     "ts-node": "^8.10.2",
     "tslint": "~6.1.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.2.3"
   }
 }


### PR DESCRIPTION
- for Angular v12.0.0-next.5 compatibility
- update Angular CLI to v12.0.0-next.5 as well

This doesn't actually fix StackBlitz for autocomplete or select. I've opened https://github.com/stackblitz/core/issues/1405 to try and get more information or assistance with that.