### PR TITLE
fix: double scroll bars on guides page

### DIFF
--- a/src/app/pages/guide-list/guide-list.scss
+++ b/src/app/pages/guide-list/guide-list.scss
@@ -1,11 +1,8 @@
 @import '../../../styles/constants';
 
-:host {
-  min-height: 100%;
-}
-
+:host,
 .docs-guide {
-  min-height: 100%;
+  height: 100%;
 }
 
 .docs-guide-list {


### PR DESCRIPTION
Fixes that the guides page has two scroll bars on Windows.

Fixes #945.