### PR TITLE
fix(csp): allow img-src of 'self' for v11.x

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -40,7 +40,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src *; frame-src https://www.youtube.com; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; child-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net https://api.github.com;"
+            "value": "upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' *; frame-src https://www.youtube.com; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; child-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net https://api.github.com;"
           }
         ]
       },


### PR DESCRIPTION
- needed for `data:image/png;base64` images used in some examples

Fixes:
![Screen Shot 2021-04-15 at 22 33 27](https://user-images.githubusercontent.com/3506071/114963728-5e764380-9e3b-11eb-9ddf-892f22eca3ce.png)
