### PR TITLE
chore: enable Ivy in StackBlitz examples

### DIFF
--- a/src/assets/stack-blitz-tests/tsconfig.json
+++ b/src/assets/stack-blitz-tests/tsconfig.json
@@ -35,6 +35,7 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
+    "enableIvy": true
   }
 }

--- a/src/assets/stack-blitz/tsconfig.json
+++ b/src/assets/stack-blitz/tsconfig.json
@@ -35,6 +35,7 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
+    "enableIvy": true
   }
 }


### PR DESCRIPTION
Fixes #940

You can test this on https://angularmaterial.dev/

As mentioned in #940, when a new release comes out, for 2-3 minutes after deployment, there will be CORS errors from their cache while the `ngcc` processes run (and AWS lambda times out) and eventually update their cache. We can minimize this by opening one of the StackBlitz examples right after deploying an update to any of the Components' packages.

This is likely worth trying since Angular v12 is making a significant push towards Ivy and we've been lagging a bit behind on this.