### PR TITLE
perf: example rendering performance improvements

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
@@ -41,15 +41,16 @@ describe('StackBlitzWriter', () => {
   });
 
   it('should append correct copyright', () => {
+    const year = new Date().getFullYear();
     expect(stackBlitzWriter._appendCopyright('test.ts', 'NoContent')).toBe(`NoContent
 
-/**  Copyright 2020 Google LLC. All Rights Reserved.
+/**  Copyright ${year} Google LLC. All Rights Reserved.
     Use of this source code is governed by an MIT-style license that
     can be found in the LICENSE file at http://angular.io/license */`);
 
     expect(stackBlitzWriter._appendCopyright('test.html', 'NoContent')).toBe(`NoContent
 
-<!-- Copyright 2020 Google LLC. All Rights Reserved.
+<!-- Copyright ${year} Google LLC. All Rights Reserved.
     Use of this source code is governed by an MIT-style license that
     can be found in the LICENSE file at http://angular.io/license -->`);
 


### PR DESCRIPTION
When generating an example in Stackblitz, we have to create a `form` element and submit it to a specific URL. The `form` has to be created eagerly, because some browsers will block us from submitting it if it is created asynchronously.

As a result of this setup, we fire off a lot of HTTP requests when an example is rendered which slows the page down. These changes make the following improvements which shave off more than a second of scripting time when transitioning from the "Overview" to "Examples". I've used the datepicker examples as a benchmark.

1. Runs the HTTP requests outside of the Angular zone so that we don't trigger change detections once each request is resolved.
2. Caches the file content so that the user doesn't have to load the same file multiple times.

I've also fixed that the copyright still said "2020".

For reference, here's what the flame chart looks like at the moment:
![Before](https://user-images.githubusercontent.com/4450522/115988380-c22a0a80-a5b9-11eb-9dad-f5ee04eb2bee.png)

And this is after these changes:
![After](https://user-images.githubusercontent.com/4450522/115988392-ce15cc80-a5b9-11eb-90e9-93709e80193d.png)
