### PR TITLE
fix(version-picker): restore the versions.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,15 @@
     ],
     "headers": [
       {
+        "source": "/assets/versions.json",
+        "headers": [
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          }
+        ]
+      },
+      {
         "source": "/**(*.@(css|js|json|html|svg))",
         "headers": [
           {
@@ -31,7 +40,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' *; frame-src https://www.youtube.com; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; child-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net https://api.github.com;"
+            "value": "upgrade-insecure-requests; default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' *; frame-src https://www.youtube.com; media-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; child-src 'self' blob:; connect-src 'self' https://material.angular.io https://www.google-analytics.com https://stats.g.doubleclick.net https://api.github.com;"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:audit:a11y:localhost": "run-p --race \"~~light-server -s dist/material-angular-io -p 4200 --quiet\" \"test:audit:a11y http://localhost:4200\" --",
     "test:audit:a11y:ci": "run-p --race \"~~light-server -s ../dist/material-angular-io -p 4200 --quiet\" \"test:audit:a11y http://localhost:4200\" --",
     "test:audit": "node tools/audit-docs",
-    "test:audit:localhost": "run-p --race \"start:static\" \"test:audit http://localhost:4200 2000\" --",
+    "test:audit:localhost": "run-p --race \"~~light-server -s dist/material-angular-io -p 4200 --quiet\" \"test:audit http://localhost:4200 2000\" --",
     "test:audit:ci": "run-p --race \"~~light-server -s ../dist/material-angular-io -p 4200 --quiet\" \"test:audit http://localhost:4200\" --",
     "~~light-server": "light-server --bind=localhost --historyindex=/index.html --no-reload"
   },

--- a/src/assets/versions.json
+++ b/src/assets/versions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "url": "https://v5.material.angular.io/",
+    "title": "5.2.5"
+  },
+  {
+    "url": "https://v6.material.angular.io/",
+    "title": "6.4.7"
+  },
+  {
+    "url": "https://v7.material.angular.io/",
+    "title": "7.3.7"
+  },
+  {
+    "url": "https://v8.material.angular.io/",
+    "title": "8.2.3"
+  },
+  {
+    "url": "https://v9.material.angular.io/",
+    "title": "9.2.4"
+  },
+  {
+    "url": "https://v10.material.angular.io/",
+    "title": "10.2.7"
+  },
+  {
+    "url": "https://material.angular.io/",
+    "title": "11.2.12"
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,8 +220,8 @@
     tslib "^2.0.0"
 
 "@angular/components-examples@angular/material2-docs-content#11.2.x":
-  version "11.2.12-sha-960093992"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/765f392129257ed860a0222e2da7b9295c63b071"
+  version "11.2.12-sha-88160798b"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/01e84b9fc2d785d3d4e627cca035cb995cf0a65f"
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
- we can't remove this until we release v12 and switch the main site to it
- add CSP connect-src rule to allow getting the versions.json file
- allow downloading the versions.json from other origins like v10.material.angular.io

Relates to #962