### PR TITLE
fix stackblitz examples not working with ivy due to missing ngcc processing

### DIFF
--- a/src/assets/stack-blitz-tests/tsconfig.json
+++ b/src/assets/stack-blitz-tests/tsconfig.json
@@ -36,6 +36,5 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
-    "enableIvy": true
   }
 }

--- a/src/assets/stack-blitz/tsconfig.json
+++ b/src/assets/stack-blitz/tsconfig.json
@@ -36,6 +36,5 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
-    "enableIvy": true
   }
 }


### PR DESCRIPTION
The StackBlitz examples are currently broken as the loaded modules from
the `turbo_modules` seem unprocessed. i.e. not processed by ngcc.

This seems to happen because StackBlitz looks for `enableIvy` in
the project tsconfig in order to determine whether NGCC bundles
should be loaded or not. We set `enableIvy` explicitly but this
seems to throw off StackBlitz, especially since Ivy is enabled by
default anyway.