### PR TITLE
feat: add cookie popup

### DIFF
--- a/src/_app-theme.scss
+++ b/src/_app-theme.scss
@@ -12,6 +12,7 @@
 @use './app/shared/footer/footer-theme';
 @use './app/shared/navbar/navbar-theme';
 @use './app/shared/table-of-contents/table-of-contents-theme';
+@use './app/shared/cookie-popup/cookie-popup-theme';
 @use './styles/api-theme';
 @use './styles/markdown-theme';
 @use './styles/svg-theme';
@@ -70,4 +71,5 @@
   @include not-found-theme.theme($theme);
   @include navbar-theme.theme($theme);
   @include table-of-contents-theme.theme($theme);
+  @include cookie-popup-theme.theme($theme);
 }

--- a/src/app/app-module.ts
+++ b/src/app/app-module.ts
@@ -7,6 +7,7 @@ import {RouterModule} from '@angular/router';
 import {MaterialDocsApp} from './material-docs-app';
 import {MATERIAL_DOCS_ROUTES} from './routes';
 import {NavBarModule} from './shared/navbar';
+import {CookiePopupModule} from './shared/cookie-popup/cookie-popup-module';
 
 @NgModule({
   imports: [
@@ -18,6 +19,7 @@ import {NavBarModule} from './shared/navbar';
       relativeLinkResolution: 'corrected'
     }),
     NavBarModule,
+    CookiePopupModule,
   ],
   declarations: [MaterialDocsApp],
   providers: [{provide: LocationStrategy, useClass: PathLocationStrategy}],

--- a/src/app/material-docs-app.html
+++ b/src/app/material-docs-app.html
@@ -1,2 +1,3 @@
+<app-cookie-popup></app-cookie-popup>
 <app-navbar class="mat-elevation-z6"></app-navbar>
 <router-outlet></router-outlet>

--- a/src/app/shared/cookie-popup/_cookie-popup-theme.scss
+++ b/src/app/shared/cookie-popup/_cookie-popup-theme.scss
@@ -1,0 +1,21 @@
+@use 'sass:map';
+@use '~@angular/material' as mat;
+
+@mixin theme($theme) {
+  $primary: map.get($theme, primary);
+  $accent: map.get($theme, accent);
+  $warn: map.get($theme, warn);
+  $background: map.get($theme, background);
+  $foreground: map.get($theme, foreground);
+  $is-dark-theme: map.get($theme, is-dark);
+
+  app-cookie-popup {
+    .popup {
+      color: if($is-dark-theme,
+        map.get(map.get(mat.$grey-palette, contrast), 50),
+        map.get(mat.$dark-theme-foreground-palette, secondary-text)
+      );
+      background: if($is-dark-theme, map.get(mat.$grey-palette, 50), #252525);
+    }
+  }
+}

--- a/src/app/shared/cookie-popup/cookie-popup-module.ts
+++ b/src/app/shared/cookie-popup/cookie-popup-module.ts
@@ -1,0 +1,11 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatButtonModule} from '@angular/material/button';
+import {CookiePopup} from './cookie-popup';
+
+@NgModule({
+  imports: [CommonModule, MatButtonModule],
+  declarations: [CookiePopup],
+  exports: [CookiePopup]
+})
+export class CookiePopupModule {}

--- a/src/app/shared/cookie-popup/cookie-popup.html
+++ b/src/app/shared/cookie-popup/cookie-popup.html
@@ -1,0 +1,13 @@
+<div class="popup" *ngIf="!hasAccepted">
+  This site uses cookies from Google to deliver its services and to analyze traffic.
+
+  <div class="buttons">
+    <a
+      href="https://policies.google.com/technologies/cookies"
+      mat-button
+      color="accent"
+      target="_blank"
+      rel="noopener">More details</a>
+    <button mat-button color="accent" (click)="accept()">Ok, Got it</button>
+  </div>
+</div>

--- a/src/app/shared/cookie-popup/cookie-popup.scss
+++ b/src/app/shared/cookie-popup/cookie-popup.scss
@@ -1,0 +1,26 @@
+@use '~@angular/cdk' as cdk;
+@use '~@angular/material' as mat;
+
+$_inner-spacing: 16px;
+
+.popup {
+  @include mat.elevation(6);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  margin: 24px;
+  max-width: 430px;
+  z-index: cdk.$overlay-container-z-index + 1;
+  padding: $_inner-spacing $_inner-spacing $_inner-spacing / 2;
+  border-radius: 4px;
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  margin: $_inner-spacing $_inner-spacing / -2 0 0;
+
+  .mat-button {
+    text-transform: uppercase;
+  }
+}

--- a/src/app/shared/cookie-popup/cookie-popup.ts
+++ b/src/app/shared/cookie-popup/cookie-popup.ts
@@ -1,0 +1,33 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+const STORAGE_KEY = 'docs-cookies';
+
+@Component({
+  selector: 'app-cookie-popup',
+  templateUrl: './cookie-popup.html',
+  styleUrls: ['./cookie-popup.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CookiePopup {
+  /** Whether the user has accepted the cookie disclaimer. */
+  hasAccepted: boolean;
+
+  constructor() {
+    // Needs to be in a try/catch, because some browsers will
+    // throw when using `localStorage` in private mode.
+    try {
+      this.hasAccepted = localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch {
+      this.hasAccepted = false;
+    }
+  }
+
+  /** Accepts the cookie disclaimer. */
+  accept() {
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {}
+
+    this.hasAccepted = true;
+  }
+}


### PR DESCRIPTION
Due to legal requirements we have to have a cookie disclaimer popup. It is always shown until the user agrees to it. After the user has agreed, the popup won't be shown on subsequent sessions.

Fixes https://github.com/angular/components/issues/22746.

**Note:** currently this doesn't have any accessibility treatment, because I'm not sure what the correct approach would be. I assume that we'd have to move focus into the cookie popup since it has more than one button, but its `role` is currently either `status` or `alert` which may not make sense to receive focus and to contain buttons.

![Angular_Material_UI_component_library_-_Google_Chr_2021-05-22_08-44-27](https://user-images.githubusercontent.com/4450522/119217353-f8d04380-bad9-11eb-9e1e-1a1cdc66a00d.png)
