### PR TITLE
refactor: add modifier badge tag

### DIFF
--- a/src/styles/_api-theme.scss
+++ b/src/styles/_api-theme.scss
@@ -30,7 +30,7 @@
     }
   }
 
-  .docs-api-async-method-marker {
+  .docs-api-modifier-method-marker {
     $async-method-marker-hue: if($is-dark-theme, 200, 400);
     background-color: mat.get-color-from-palette($primary, $async-method-marker-hue);
     color: mat.get-color-from-palette($primary, '#{$async-method-marker-hue}-contrast');

--- a/src/styles/_api.scss
+++ b/src/styles/_api.scss
@@ -85,11 +85,11 @@
   font-size: 18px;
 }
 
-.docs-api-async-method-marker {
+.docs-api-modifier-method-marker {
   display: inline-block;
   vertical-align: baseline;
   padding: 2px 7px;
-  margin: 0 12px 0 0;
+  margin-right: 12px;
   border-radius: 5px;
   font-size: 13px;
 }


### PR DESCRIPTION
Replaces the `async` method marker with a generic marker that can also be used for static methods.

Related to https://github.com/angular/components/pull/22786.