### PR TITLE
fix: cache fetched docs

### DIFF
--- a/src/app/shared/doc-viewer/doc-viewer.spec.ts
+++ b/src/app/shared/doc-viewer/doc-viewer.spec.ts
@@ -118,7 +118,7 @@ describe('DocViewer', () => {
   });
 
   it('should show error message when doc not found', () => {
-    spyOn(console, 'log');
+    spyOn(console, 'error');
 
     const fixture = TestBed.createComponent(DocViewerTestComponent);
     const docViewer = fixture.debugElement.query(By.directive(DocViewer));
@@ -138,7 +138,7 @@ describe('DocViewer', () => {
     expect(docViewer).not.toBeNull();
     expect(docViewer.nativeElement.innerHTML).toContain(
         'Failed to load document: http://material.angular.io/error-doc.html');
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(1);
   });
 
   // TODO(mmalerba): Add test that example-viewer is instantiated.


### PR DESCRIPTION
Currently we fetch a doc every time we need to display it which means that user navigating between two pages will have to request the same information multiple times.

These changes add a caching layer since the information isn't going to change.