### PR TITLE
refactor: remove default form field appearance in Stackblitz

### DIFF
--- a/src/assets/stack-blitz/src/main.ts
+++ b/src/assets/stack-blitz/src/main.ts
@@ -6,13 +6,9 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {DemoMaterialModule} from './app/material-module';
-import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 
 import {MaterialDocsExample} from './app/material-docs-example';
 
-// Default MatFormField appearance to 'fill' as that is the new recommended approach and the
-// `legacy` and `standard` appearances are scheduled for deprecation in version 10.
-// This makes the examples that use MatFormField render the same in StackBlitz as on the docs site.
 @NgModule({
   imports: [
     BrowserModule,
@@ -25,10 +21,7 @@ import {MaterialDocsExample} from './app/material-docs-example';
   ],
   entryComponents: [MaterialDocsExample],
   declarations: [MaterialDocsExample],
-  bootstrap: [MaterialDocsExample],
-  providers: [
-    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'fill' } },
-  ]
+  bootstrap: [MaterialDocsExample]
 })
 export class AppModule {}
 


### PR DESCRIPTION
Companion PR to https://github.com/angular/components/pull/22837. Removes the default form field appearance so that we get a consistent result between the docs site and Stackblitz.