### PR TITLE
fix: align and clean up table design

### DIFF
--- a/src/styles/_markdown-theme.scss
+++ b/src/styles/_markdown-theme.scss
@@ -33,11 +33,5 @@
     code {
       background: rgba(mat.get-color-from-palette($foreground, secondary-text), $exportBackgroundOpacity);
     }
-
-    > table {
-      th, td {
-        border-bottom-color: mat.get-color-from-palette($foreground, divider);
-      }
-    }
   }
 }

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -52,30 +52,6 @@
   code {
     padding: 3px;
   }
-
-  // Target direct descendants here so that the styles don't bleed into the live examples.
-  > table {
-    text-align: left;
-    table-layout: fixed;
-    border-collapse: collapse;
-    margin-bottom: 1em;
-    font-size: 14px;
-
-    tr {
-      height: 48px;
-    }
-
-    th, td {
-      padding: 8px 4px 8px 0;
-      border-bottom-width: 1px;
-      border-bottom-style: solid;
-    }
-
-    // Code tends to wrap inside tables which doesn't look great with the background color.
-    code {
-      background: transparent;
-    }
-  }
 }
 
 .docs-header-link {

--- a/src/styles/_tables-theme.scss
+++ b/src/styles/_tables-theme.scss
@@ -3,26 +3,23 @@
 
 // Mixin to apply theme colors for both generated API docs and markdown docs (guides/overviews).
 @mixin theme($theme) {
-  $primary: map.get($theme, primary);
-  $accent: map.get($theme, accent);
-  $warn: map.get($theme, warn);
   $background: map.get($theme, background);
   $foreground: map.get($theme, foreground);
-  $is-dark-theme: map.get($theme, is-dark);
-  $tableBorderOpacity: if($is-dark-theme, 0.08, 0.03);
 
   .docs-api table,
-  .docs-markdown-table {
+  .docs-markdown > table {
     color: mat.get-color-from-palette($foreground, text);
   }
 
   .docs-api th,
-  .docs-markdown-th {
+  .docs-markdown > table th {
     background: mat.get-color-from-palette($background, app-bar);
   }
 
   .docs-api td,
-  .docs-markdown-td {
-    border: 1px solid rgba(mat.get-color-from-palette($foreground, secondary-text), $tableBorderOpacity);
+  .docs-api thead,
+  .docs-markdown > table td,
+  .docs-markdown > table thead {
+    border: 1px solid mat.get-color-from-palette($foreground, divider);
   }
 }

--- a/src/styles/_tables.scss
+++ b/src/styles/_tables.scss
@@ -1,25 +1,35 @@
 @use './constants';
 
 .docs-api table,
-.docs-markdown-table {
+.docs-markdown > table {
   border-collapse: collapse;
-  border-radius: 2px;
   border-spacing: 0;
-  margin: 0 0 32px 0;
+  margin: 0 0 32px;
   width: 100%;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.24), 0 0 2px rgba(0, 0, 0, 0.12);
 }
 
+
+// Styles specific only to the table inside markdown.
+.docs-markdown > table {
+  font-size: 14px;
+
+  // Code tends to wrap inside tables which doesn't look great with the background color.
+  code {
+    background: transparent;
+  }
+}
+
+
 .docs-api th,
-.docs-markdown-th {
+.docs-markdown > table th {
   font-weight: 400;
   max-width: 100px;
-  padding: 13px 16px;
+  padding: 14px 16px;
   text-align: left;
 }
 
 .docs-api td,
-.docs-markdown-td {
+.docs-markdown > table td {
   font-weight: 400;
   padding: 8px 16px;
 
@@ -37,17 +47,17 @@
 
 @media (max-width: constants.$small-breakpoint-width) {
   .docs-api table,
-  .docs-markdown-table {
+  .docs-markdown > table {
     margin: 0 0 32px 0;
   }
 
   .docs-api th,
-  .docs-markdown-th {
+  .docs-markdown > table th {
     padding: 6px 16px;
   }
 
   .docs-api td,
-  .docs-markdown-td {
+  .docs-markdown > table td {
     padding: 4px 8px;
   }
 }


### PR DESCRIPTION
* Aligns the design between the tables inside markdown and the tables in the API docs. I chose to go with the design from the API docs, because the separation between cells is much better.
* Fixes the poor color contrast on the table border by using the correct theming variables.
* Removes the table box shadow and fixes up some spacings to make the tables look better.

Before:
![before](https://user-images.githubusercontent.com/4450522/120024131-082a2200-bfef-11eb-83e3-4d6188b252ea.png)

After (note that this applies to tables in the API docs too):
![after](https://user-images.githubusercontent.com/4450522/120024162-14ae7a80-bfef-11eb-81a8-2796a702d77b.png)
