### PR TITLE
feat: expose CDK accordion docs

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -392,6 +392,14 @@ const DOCS: { [key: string]: DocItem[] } = {
       },
     },
     {
+      id: 'accordion',
+      name: 'Accordion',
+      summary: 'Component with one or more expandable sections.',
+      exampleSpecs: {
+        prefix: 'cdk-accordion-',
+      },
+    },
+    {
       id: 'bidi',
       name: 'Bidirectionality',
       summary: 'Utilities to respond to changes in LTR/RTL layout direction.',


### PR DESCRIPTION
Follow-up to https://github.com/angular/components/pull/22829. Exposes the CDK accordion docs in the navigation.