### PR TITLE
perf: avoid triggering change detection on scroll

### DIFF
--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -1,5 +1,13 @@
 import {
-  AfterViewInit, Component, ElementRef, Inject, Input, OnDestroy, OnInit
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit,
+  NgZone,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ActivatedRoute, Router} from '@angular/router';
@@ -39,9 +47,9 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
 
   _linkSections: LinkSection[] = [];
   _links: Link[] = [];
-
   _rootUrl = this._router.url.split('#')[0];
-  private _scrollContainer: any;
+
+  private _scrollContainer: HTMLElement | Window | null = null;
   private _urlFragment = '';
   private subscriptions = new Subscription();
 
@@ -49,7 +57,9 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
               private _route: ActivatedRoute,
               private _element: ElementRef,
               private _navigationFocusService: NavigationFocusService,
-              @Inject(DOCUMENT) private _document: Document) {
+              @Inject(DOCUMENT) private _document: Document,
+              private _ngZone: NgZone,
+              private _changeDetectorRef: ChangeDetectorRef) {
 
     this.subscriptions.add(this._navigationFocusService.navigationEndEvents
       .subscribe(() => {
@@ -74,15 +84,18 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     // On init, the sidenav content element doesn't yet exist, so it's not possible
     // to subscribe to its scroll event until next tick (when it does exist).
-    Promise.resolve().then(() => {
-      this._scrollContainer = this.container ?
-        this._document.querySelectorAll(this.container)[0] : window;
+    this._ngZone.runOutsideAngular(() => {
+      Promise.resolve().then(() => {
+        this._scrollContainer = this.container ?
+          this._document.querySelector(this.container) as HTMLElement :
+          window;
 
-      if (this._scrollContainer) {
-        this.subscriptions.add(fromEvent(this._scrollContainer, 'scroll').pipe(
-            debounceTime(10))
-            .subscribe(() => this.onScroll()));
-      }
+        if (this._scrollContainer) {
+          this.subscriptions.add(fromEvent(this._scrollContainer, 'scroll').pipe(
+              debounceTime(10))
+              .subscribe(() => this.onScroll()));
+        }
+      });
     });
   }
 
@@ -95,10 +108,7 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   updateScrollPosition(): void {
-    const target = document.getElementById(this._urlFragment);
-    if (target) {
-      target.scrollIntoView();
-    }
+    this._document.getElementById(this._urlFragment)?.scrollIntoView();
   }
 
   resetHeaders() {
@@ -107,20 +117,19 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   addHeaders(sectionName: string, docViewerContent: HTMLElement, sectionIndex = 0) {
-    const headers = Array.from<HTMLHeadingElement>(docViewerContent.querySelectorAll('h3, h4'));
-    const links: Link[] = [];
-    headers.forEach((header) => {
+    const links = Array.from(docViewerContent.querySelectorAll('h3, h4'), header => {
       // remove the 'link' icon name from the inner text
-      const name = header.innerText.trim().replace(/^link/, '');
+      const name = (header as HTMLElement).innerText.trim().replace(/^link/, '');
       const {top} = header.getBoundingClientRect();
-      links.push({
+      return {
         name,
         type: header.tagName.toLowerCase(),
         top: top,
         id: header.id,
         active: false
-      });
+      };
     });
+
     this._linkSections[sectionIndex] = {name: sectionName, links};
     this._links.push(...links);
   }
@@ -128,24 +137,39 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   /** Gets the scroll offset of the scroll container */
   private getScrollOffset(): number | void {
     const {top} = this._element.nativeElement.getBoundingClientRect();
-    if (typeof this._scrollContainer.scrollTop !== 'undefined') {
-      return this._scrollContainer.scrollTop + top;
-    } else if (typeof this._scrollContainer.pageYOffset !== 'undefined') {
-      return this._scrollContainer.pageYOffset + top;
+    const container = this._scrollContainer;
+
+    if (container instanceof HTMLElement) {
+      return container.scrollTop + top;
+    }
+
+    if (container) {
+      return container.pageYOffset + top;
     }
   }
 
   private onScroll(): void {
+    const scrollOffset = this.getScrollOffset();
+    let hasChanged = false;
+
     for (let i = 0; i < this._links.length; i++) {
-      this._links[i].active = this.isLinkActive(this._links[i], this._links[i + 1]);
+      // A link is considered active if the page is scrolled past the
+      // anchor without also being scrolled passed the next link.
+      const currentLink = this._links[i];
+      const nextLink = this._links[i + 1];
+      const isActive = scrollOffset >= currentLink.top &&
+                       (!nextLink || nextLink.top >= scrollOffset);
+
+      if (isActive !== currentLink.active) {
+        currentLink.active = isActive;
+        hasChanged = true;
+      }
+    }
+
+    if (hasChanged) {
+      // The scroll listener runs outside of the Angular zone so
+      // we need to bring it back in only when something has changed.
+      this._ngZone.run(() => this._changeDetectorRef.markForCheck());
     }
   }
-
-  private isLinkActive(currentLink: any, nextLink: any): boolean {
-    // A link is considered active if the page is scrolled passed the anchor without also
-    // being scrolled passed the next link
-    const scrollOffset = this.getScrollOffset();
-    return scrollOffset >= currentLink.top && !(nextLink && nextLink.top < scrollOffset);
-  }
-
 }


### PR DESCRIPTION
Fixes that the table of contents was triggering change detections while scrolling.