### PR TITLE
release: update the version for the 12.2.0 release

### DIFF
--- a/src/assets/versions.json
+++ b/src/assets/versions.json
@@ -1,7 +1,7 @@
 [
   {
     "url": "https://material.angular.io/",
-    "title": "12.1.4"
+    "title": "12.2.0"
   },
   {
     "url": "https://v11.material.angular.io/",


### PR DESCRIPTION
updates the versions.json file for the 12.2.0 release. No need to update package.json and yan.lock because that was already done in https://github.com/angular/material.angular.io/commit/49609bae77c59bdd518aee643dc141acd0a1ae55