### PR TITLE
fix: temporarily disable Ivy on Stackblitz

### DIFF
--- a/src/assets/stack-blitz/tsconfig.json
+++ b/src/assets/stack-blitz/tsconfig.json
@@ -36,6 +36,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
-    "enableIvy": true
+    "enableIvy": false
   }
 }


### PR DESCRIPTION
Stackblitz has a race condition that an cause issues when running ngcc against our packages, resulting in errors.

These changes temporarily disable Ivy until we can start using the linker.