### PR TITLE
build: remove IE compatibility

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -14,4 +14,4 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-IE 11
+not IE 11

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
   <base href="/">
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="translucent">


### PR DESCRIPTION
Drops IE from the `.browserslistrc` and an IE-specific `meta` tag.