### PR TITLE
fix: ensure that menu items are always sorted

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.spec.ts
+++ b/src/app/shared/documentation-items/documentation-items.spec.ts
@@ -31,13 +31,13 @@ describe('DocViewer', () => {
   });
 
   it('should be sorted alphabetically (components)', () => {
-    const components = docsItems.getItems(COMPONENTS).map(c => c.id);
+    const components = docsItems.getItems(COMPONENTS).map(c => c.name);
     const sortedComponents = components.concat().sort();
     expect(components).toEqual(sortedComponents);
   });
 
   it('should be sorted alphabetically (cdk)', () => {
-    const cdk = docsItems.getItems(CDK).map(c => c.id);
+    const cdk = docsItems.getItems(CDK).map(c => c.name);
     const sortedCdk = cdk.concat().sort();
     expect(cdk).toEqual(sortedCdk);
   });

--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -546,25 +546,9 @@ const DOCS: { [key: string]: DocItem[] } = {
   // docs more granularly than directory-level (within a11y) (same for viewport).
 };
 
-for (const doc of DOCS[COMPONENTS]) {
-  doc.packageName = 'material';
-  doc.examples =
-    exampleNames
-      .filter(key => key.match(RegExp(`^${doc.exampleSpecs.prefix}`)) &&
-        !doc.exampleSpecs.exclude?.some(excludeName => key.indexOf(excludeName) === 0));
-}
-
-for (const doc of DOCS[CDK]) {
-  doc.packageName = 'cdk';
-  doc.examples =
-    exampleNames
-      .filter(key => key.match(RegExp(`^${doc.exampleSpecs.prefix}`)) &&
-        !doc.exampleSpecs.exclude?.includes(key));
-}
-
-const ALL_COMPONENTS = DOCS[COMPONENTS];
-const ALL_CDK = DOCS[CDK];
-const ALL_DOCS = ALL_COMPONENTS.concat(ALL_CDK);
+const ALL_COMPONENTS = processDocs('material', DOCS[COMPONENTS]);
+const ALL_CDK = processDocs('cdk', DOCS[CDK]);
+const ALL_DOCS = [...ALL_COMPONENTS, ...ALL_CDK];
 
 @Injectable()
 export class DocumentationItems {
@@ -583,4 +567,15 @@ export class DocumentationItems {
     const sectionLookup = section === 'cdk' ? 'cdk' : 'material';
     return ALL_DOCS.find(doc => doc.id === id && doc.packageName === sectionLookup);
   }
+}
+
+function processDocs(packageName: string, docs: DocItem[]): DocItem[] {
+  for (const doc of docs) {
+    doc.packageName = packageName;
+    doc.examples = exampleNames.filter(key =>
+      key.match(RegExp(`^${doc.exampleSpecs.prefix}`)) &&
+      !doc.exampleSpecs.exclude?.some(excludeName => key.indexOf(excludeName) === 0));
+  }
+
+  return docs.sort((a, b) => a.name.localeCompare(b.name, 'en'));
 }


### PR DESCRIPTION
De-duplicates some logic and adds programmatic sorting of the menu items so that we don't have to do it manually. Currently the "Component harnesses" menu item is out of order.