### PR TITLE
fix: include cdkAccordionModule in material-module for accordion stackblitz demo

### DIFF
--- a/src/assets/stack-blitz/src/app/material-module.ts
+++ b/src/assets/stack-blitz/src/app/material-module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from '@angular/core';
 import {A11yModule} from '@angular/cdk/a11y';
+import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {ClipboardModule} from '@angular/cdk/clipboard';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {PortalModule} from '@angular/cdk/portal';
@@ -46,6 +47,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 @NgModule({
   exports: [
     A11yModule,
+    CdkAccordionModule,
     ClipboardModule,
     CdkStepperModule,
     CdkTableModule,


### PR DESCRIPTION
Currently the stackblitz demo for [accordion](https://material.angular.io/cdk/accordion/overview) doesn't work by default.  This adds CdkAccordionModule to material-module to fix this issue.