### PR TITLE
fix: github icon was not centered on mobile

### DIFF
--- a/src/app/shared/navbar/navbar.html
+++ b/src/app/shared/navbar/navbar.html
@@ -29,7 +29,7 @@
   </a>
   <a mat-icon-button class="docs-button docs-navbar-show-small"
      href="https://github.com/angular/components" aria-label="GitHub Repository">
-    <img class="docs-angular-logo"
+    <img class="docs-angular-logo docs-navbar--github-logo"
          src="../../../assets/img/homepage/github-circle-white-transparent.svg"
          alt="angular">
   </a>


### PR DESCRIPTION
The class was already there but not used.