### PR TITLE
fix: temporarily disable Ivy on Stackblitz (#1050)

### DIFF
--- a/src/assets/stack-blitz/tsconfig.json
+++ b/src/assets/stack-blitz/tsconfig.json
@@ -36,6 +36,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,
-    "enableIvy": true
+    "enableIvy": false
   }
 }


### PR DESCRIPTION
Stackblitz has a race condition that causes issues when running ngcc against our packages, resulting in errors.

These changes temporarily disable Ivy until we can start using the linker.

(cherry picked from commit f41506ac505206763b384808e196a6bb2459d1d5)

Closes #1076 