### PR TITLE
refactor: update stackblitz boilerplate to setup test environment

### DIFF
--- a/src/assets/stack-blitz/src/test.ts
+++ b/src/assets/stack-blitz/src/test.ts
@@ -1,6 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import 'zone.js/testing';
+import {getTestBed} from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {
   context(path: string, deep?: boolean, filter?: RegExp): {
@@ -11,10 +16,10 @@ declare const require: {
 
 // First, initialize the Angular testing environment.
 // TODO: Re-enable this once example test specs no longer init the test environment manually.
-/*getTestBed().initTestEnvironment(
+getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
-);*/
+);
 
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/src/assets/stack-blitz/src/test.ts
+++ b/src/assets/stack-blitz/src/test.ts
@@ -15,7 +15,6 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-// TODO: Re-enable this once example test specs no longer init the test environment manually.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,8 +258,8 @@
     tslib "^2.3.0"
 
 "@angular/components-examples@angular/material2-docs-content#13.0.x":
-  version "13.0.0-rc.1"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/93a973a9b7dc616626b408f980228ce9849fce93"
+  version "13.0.0-rc.2"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/383365b878d35fe59c5efa24fa25cba516f7d82a"
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
We removed the test environment calls from the harness example spec
files so that the standard CLI `test.ts` file can initialize the
test browser environment. This commit updates the SHA of the docs
content and re-adds the `test.ts` init environment logic.

https://github.com/angular/components/commit/88b718e8d947def1dc8c03050a4fb12fbe1e4ace