### PR TITLE
Always load versions from latest material.angular.io

### DIFF
--- a/src/app/shared/version-picker/version-picker.ts
+++ b/src/app/shared/version-picker/version-picker.ts
@@ -7,7 +7,7 @@ import {MatMenuModule} from '@angular/material/menu';
 import {VERSION} from '@angular/material/core';
 import {MatTooltipModule} from '@angular/material/tooltip';
 
-const versionUrl = 'assets/versions.json';
+const versionUrl = 'https://material.angular.io/assets/versions.json';
 
 /** Version information with title and redirect url */
 interface VersionInfo {


### PR DESCRIPTION
PR #645 erroneously changed this to a relative url. We want this to always use the latest material.angular.io so that we don't have to update old branches for new major versions.
