### PR TITLE
refactor: transfer favicon to stackBlitz

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -35,6 +35,7 @@ export const TEMPLATE_FILES = [
   'tsconfig.app.json',
   'tsconfig.json',
   'tsconfig.spec.json',
+  'src/favicon.ico',
   'src/index.html',
   'src/main.ts',
   'src/material.module.ts',


### PR DESCRIPTION
A `favicon.ico` is stored in `assets/stack-blitz/src` but not sent to stackBlitz. So despite `favicon.ico` in assets, it is currently not used anywhere.

Another solution would be to delete `favicon.ico`.