### PR TITLE
build: fix crash in deploy script due to pipefail

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -36,7 +36,7 @@ projectId=${PROJECT_ID[$version, $mode]}
 
 # Prevent deployment if we have a pre-release version, using the cdk
 # version as a proxy for all components repo package versions.
-cdk_prerelease=$(cat package.json | grep cdk | egrep next\|rc)
+cdk_prerelease=$(cat package.json | grep cdk | egrep next\|rc || true)
 if [[ "${cdk_prerelease}" ]]; then
   if [[ "${version}" == "stable" && "${mode}" == "prod" ]]; then
     echo "Cannot publish a prerelease version to stable prod"


### PR DESCRIPTION
Fixes the tools/deploy.sh script failing silently when determining if it
has a pre-release version

```
cdk_prerelease=$(cat package.json | grep cdk | egrep next\|rc
```

^ Since this script has `pipefail` set, egrep would exit with code 1 and
cause the entire script to exit with code 1. Fixes this by adding an `||
true`, so that we don't crash when the script cannot recognize a
pre-release version. egrep is expected to exit with 1 if this is neither
a next nor rc version