### PR TITLE
Fix forking and saving for webcontainer stackblitz examples

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.spec.ts
@@ -115,7 +115,7 @@ describe('StackBlitzWriter', () => {
       'src/app/app.module.ts': `import {ExampleComponent, AdditionalComp} from './test';`,
       'src/app/test.ts': `ExampleComponent
 
-/**  Copyright 2021 Google LLC. All Rights Reserved.
+/**  Copyright ${new Date().getFullYear()} Google LLC. All Rights Reserved.
     Use of this source code is governed by an MIT-style license that
     can be found in the LICENSE file at https://angular.io/license */`,
     });

--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -24,6 +24,10 @@ const TEMPLATE_PATH = '/assets/stack-blitz/';
 /**
  * List of boilerplate files for an example StackBlitz.
  * This currently matches files needed for a basic Angular CLI project.
+ * 
+ * Note: The template files match up with a basic app generated through `ng new`.
+ * StackBlitz does not support binary files like `favicon.ico`, so we removed that
+ * file from the boilerplate.
  */
 export const TEMPLATE_FILES = [
   '.gitignore',
@@ -35,7 +39,6 @@ export const TEMPLATE_FILES = [
   'tsconfig.app.json',
   'tsconfig.json',
   'tsconfig.spec.json',
-  'src/favicon.ico',
   'src/index.html',
   'src/main.ts',
   'src/material.module.ts',

--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -24,7 +24,7 @@ const TEMPLATE_PATH = '/assets/stack-blitz/';
 /**
  * List of boilerplate files for an example StackBlitz.
  * This currently matches files needed for a basic Angular CLI project.
- * 
+ *
  * Note: The template files match up with a basic app generated through `ng new`.
  * StackBlitz does not support binary files like `favicon.ico`, so we removed that
  * file from the boilerplate.

--- a/src/assets/stack-blitz/angular.json
+++ b/src/assets/stack-blitz/angular.json
@@ -27,7 +27,6 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
-              "src/favicon.ico",
               "src/assets"
             ],
             "styles": [
@@ -99,7 +98,6 @@
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
             "assets": [
-              "src/favicon.ico",
               "src/assets"
             ],
             "stylePreprocessorOptions": {

--- a/src/assets/stack-blitz/src/index.html
+++ b/src/assets/stack-blitz/src/index.html
@@ -5,7 +5,6 @@
   <title>${title}</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
Fixes the forking and saving functionality for WebContainer StackBlitz
examples. The saving/forking functionality did not work (no proper error though)
because we delivered a binary `.ico` file to StackBlitz.

To fix the examples, we will remove the `favicon.ico` file, even the goal
was to keep the examples as equivalent as possible to a `ng new`-created app.

It's surprising this worked in the past, but the StackBlitz SDK mentions that no binary files
are supported and this breaks the saving, according to my investigation. Still would be good
if StackBlitz would have a better error indication I guess (lots of people submitted issues on their end)