### PR TITLE
Fix docs-content version mismatch for v13.x docs deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/cdk-experimental": "^13.2.3",
     "@angular/common": "^13.1.0",
     "@angular/compiler": "^13.1.0",
-    "@angular/components-examples": "angular/material2-docs-content#master",
+    "@angular/components-examples": "angular/material2-docs-content#13.2.x",
     "@angular/core": "^13.1.0",
     "@angular/forms": "^13.1.0",
     "@angular/google-maps": "^13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,9 +257,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/components-examples@angular/material2-docs-content#master":
-  version "14.0.0-next.3"
-  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/eb67ef2562dc930f47219f7b5ae847781e348504"
+"@angular/components-examples@angular/material2-docs-content#13.2.x":
+  version "13.2.3"
+  resolved "https://codeload.github.com/angular/material2-docs-content/tar.gz/b4c279371ec953fe98a30b9adb8e02f65e2735d1"
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
The docs app currently deployed to `material.angular.io` is for Angular
Components v13, but relies on docs-content from `master` i.e. v14-next.

We should scope the docs-content to v13.2.x (the latest and last minor for
v13) for the v13.x docs deployment.