### PR TITLE
build: set firebase hosting target name to support multi-site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ ui-debug.log
 .firebase/
 /typings
 
+.firebaserc
+
 #System Files
 .DS_Store
 Thumbs.db

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "https://raw.githubusercontent.com/firebase/firebase-tools/master/schema/firebase-config.json",
   "hosting": {
+    "target": "mat-aio",
     "public": "dist/material-angular-io",
     "cleanUrls": true,
     "rewrites": [

--- a/src/app/shared/normalized-version.ts
+++ b/src/app/shared/normalized-version.ts
@@ -1,0 +1,11 @@
+import {VERSION} from '@angular/material/core';
+
+/**
+ * Normalized Material version without its additional SHA information if present.
+ *
+ * Snapshot builds of Angular will include these as part of their ng-dev release
+ * stamping. We only want to show the SHA details in the footer of the page.
+ *
+ * e.g. `14.0.0-next.3+38.sha-9d233f4` should become `14.0.0-next.3`
+ */
+export const normalizedMaterialVersion = VERSION.full.match(/(\d+\.\d+\.\d+(?:[^\+]*))/)![1];

--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -1,11 +1,11 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable, NgZone} from '@angular/core';
-import {VERSION as MAT_VERSION} from '@angular/material/core';
 import {EXAMPLE_COMPONENTS, ExampleData} from '@angular/components-examples';
 import {Observable} from 'rxjs';
 import {shareReplay, take} from 'rxjs/operators';
 
 import stackblitz from '@stackblitz/sdk';
+import {normalizedMaterialVersion} from '../normalized-version';
 
 const COPYRIGHT =
   `Copyright ${new Date().getFullYear()} Google LLC. All Rights Reserved.
@@ -163,7 +163,7 @@ export class StackBlitzWriter {
     // seems to be able to partially re-use the lock file to speed up the module tree computation,
     // so providing a lock file is still reasonable while modifying the `package.json`.
     if (fileName === 'src/index.html' || fileName === 'package.json') {
-      fileContent = fileContent.replace(/\${version}/g, MAT_VERSION.full);
+      fileContent = fileContent.replace(/\${version}/g, normalizedMaterialVersion);
     }
 
     if (fileName === 'src/index.html') {

--- a/src/app/shared/version-picker/version-picker.ts
+++ b/src/app/shared/version-picker/version-picker.ts
@@ -4,8 +4,8 @@ import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatMenuModule} from '@angular/material/menu';
-import {VERSION} from '@angular/material/core';
 import {MatTooltipModule} from '@angular/material/tooltip';
+import {normalizedMaterialVersion} from '../normalized-version';
 
 const versionUrl = 'https://material.angular.io/assets/versions.json';
 
@@ -17,11 +17,11 @@ interface VersionInfo {
 
 @Component({
   selector: 'version-picker',
-  templateUrl: './version-picker.html'
+  templateUrl: './version-picker.html',
 })
 export class VersionPicker {
   /** The currently running version of Material. */
-  materialVersion = VERSION.full;
+  materialVersion = normalizedMaterialVersion;
   /** The possible versions of the doc site. */
   docVersions = this.http.get<VersionInfo[]>(versionUrl);
 
@@ -41,6 +41,6 @@ export class VersionPicker {
 @NgModule({
   imports: [MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule, CommonModule],
   exports: [VersionPicker],
-  declarations: [VersionPicker]
+  declarations: [VersionPicker],
 })
 export class VersionPickerModule {}

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -54,4 +54,6 @@ read -rp "Press <ENTER> to continue.."
 
 yarn prod-build
 yarn firebase use $projectId
-yarn firebase deploy
+yarn firebase target:clear hosting mat-aio
+yarn firebase target:apply hosting mat-aio $projectId
+yarn firebase deploy --only hosting:mat-aio


### PR DESCRIPTION
Sets up a Firebase hosting target name for the docs hosting. This is
useful when we want to support multi-sites for a single project.

This is currenlty a noop but will be useful when we auto-deploy
the docs site leveraging Firebase multi-sites (like FW does)