### PR TITLE
Avoid analytics prompt of CLI in stackblitz examples

### DIFF
--- a/src/assets/stack-blitz/angular.json
+++ b/src/assets/stack-blitz/angular.json
@@ -1,6 +1,9 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
+  "cli": {
+    "analytics": false
+  },
   "newProjectRoot": "projects",
   "projects": {
     "example-app": {


### PR DESCRIPTION
The prompt will prevent the examples from running automatically in
StackBlitz, now requiring user action to proceed with serving.

We should disable this as this setting is not persisted across
StackBlitz projects anyway..