### PR TITLE
Rework caching header rules in an attempt to fix caching issues

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,16 +16,9 @@
         "headers": [
           {
             "key": "Cache-Control",
+            // The `index.html` file (or when loaded as SPA), should never be cached. Older
+            // JavaScript sources and assets would be loaded that might no longer be available.
             "value": "no-cache"
-          }
-        ]
-      },
-      {
-        "source": "/assets/versions.json",
-        "headers": [
-          {
-            "key": "Access-Control-Allow-Origin",
-            "value": "*"
           }
         ]
       },
@@ -60,25 +53,44 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "public, max-age=15811200, s-maxage=31536000"
+            // Images and SVGs are not hashed but are also expected to change rarely.
+            // There are a lot of SVGs in our docs app, and we want to cache them longer.
+            "value": "public, max-age=8640000" // 100 days.
           }
         ]
       },
       {
-        "source": "/*.svg",
+        "source": "/assets/versions.json",
         "headers": [
           {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          },
+          {
             "key": "Cache-Control",
-            "value": "public, max-age=31536000"
+            // The versions file should not be cached for too long since we are
+            // deploying on a weekly basis and this file is rather small.
+            "value": "public, max-age=604800" // 7 days.
           }
         ]
       },
       {
-        "source": "/*.@(webmanifest|ico)",
+        "source": "/assets/stack-blitz/**",
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "public, max-age=604800, s-maxage=1209600"
+            // StackBlitz assets are not hashed and should not be cached.
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/*.ico",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            // Icons and the favicon are expected to change rarely. We cache it, but not for too long.
+            "value": "public, max-age=2592000" // 30 days.
           }
         ]
       },
@@ -87,17 +99,13 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "public, max-age=31536000"
+            // JS ans CSS files are hashed and can be cached indefinitely.
+            "value": "public, max-age=31536000" // 365 days.
           }
         ]
       }
     ],
-    "ignore": [
-      "firebase.json",
-      "**/node_modules/**",
-      "tmp",
-      "deploy"
-    ]
+    "ignore": ["firebase.json", "**/node_modules/**", "tmp", "deploy"]
   },
   "emulators": {
     "hosting": {


### PR DESCRIPTION
e.g. StackBlitz assets should not be cached indefinitely as otherwise e.g. we might end up with Angular v13 and CDK/Material v14, breaking examples..