### PR TITLE
fix: add material-moment-adapter to stackblitz dependencies

### DIFF
--- a/src/assets/stack-blitz/package-lock.json
+++ b/src/assets/stack-blitz/package-lock.json
@@ -9,15 +9,17 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~14.0.0",
-        "@angular/cdk": "~14.0.0",
+        "@angular/cdk": "14.0.3",
         "@angular/common": "~14.0.0",
         "@angular/compiler": "~14.0.0",
         "@angular/core": "~14.0.0",
         "@angular/forms": "~14.0.0",
-        "@angular/material": "~14.0.0",
+        "@angular/material": "14.0.3",
+        "@angular/material-moment-adapter": "14.0.3",
         "@angular/platform-browser": "~14.0.0",
         "@angular/platform-browser-dynamic": "~14.0.0",
         "@angular/router": "~14.0.0",
+        "moment": "^2.18.1",
         "rxjs": "~7.4.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.5"
@@ -410,9 +412,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.0.0.tgz",
-      "integrity": "sha512-9RnDlvskjXt1il9uWUidfHE98J9eYaVn+MCqhg0VLH1uHFcpt/dzoJ1nv71mC0anZHrClax29YMiEBnPFZaeFQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.0.3.tgz",
+      "integrity": "sha512-XN5+WVUFx13lW2x9gnzJprHGqcvSpKQaoXxFvlcn16i0P6Iy1jldVZm6q6chEhgX9rEi7P31nfE88OJzHmkEyw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -585,20 +587,33 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.0.0.tgz",
-      "integrity": "sha512-RNV1g7DbnlSI9rjsuqH+fO2e+IQCJEJmjBRGvx6dBYugiag4iR9ZnpHNued26UTJ+BPTemTA7a4cDzseKKB6NQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.0.3.tgz",
+      "integrity": "sha512-xtYV5ygkfl/6JUaI99NeD1AdM4WcCrCOsx/5IR3ZohUQ1q9vPPvcArWa9QAa1GgU7HNhkgXU90yELwsOtSTc4w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/animations": "^14.0.0 || ^15.0.0",
-        "@angular/cdk": "14.0.0",
+        "@angular/cdk": "14.0.3",
         "@angular/common": "^14.0.0 || ^15.0.0",
         "@angular/core": "^14.0.0 || ^15.0.0",
         "@angular/forms": "^14.0.0 || ^15.0.0",
         "@angular/platform-browser": "^14.0.0 || ^15.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material-moment-adapter": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-14.0.3.tgz",
+      "integrity": "sha512-Lf6Hug+/e3OPa6rQuvheIS2yM/Acq7fv+WsYwfo23s7xA6z5ScqsHgMZlKre8upnaFGJWMmEQbjziUVnwX8GfQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^14.0.0 || ^15.0.0",
+        "@angular/material": "14.0.3",
+        "moment": "^2.18.1"
       }
     },
     "node_modules/@angular/platform-browser": {
@@ -7817,6 +7832,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11902,9 +11925,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.0.0.tgz",
-      "integrity": "sha512-9RnDlvskjXt1il9uWUidfHE98J9eYaVn+MCqhg0VLH1uHFcpt/dzoJ1nv71mC0anZHrClax29YMiEBnPFZaeFQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.0.3.tgz",
+      "integrity": "sha512-XN5+WVUFx13lW2x9gnzJprHGqcvSpKQaoXxFvlcn16i0P6Iy1jldVZm6q6chEhgX9rEi7P31nfE88OJzHmkEyw==",
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^2.3.0"
@@ -12009,9 +12032,17 @@
       }
     },
     "@angular/material": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.0.0.tgz",
-      "integrity": "sha512-RNV1g7DbnlSI9rjsuqH+fO2e+IQCJEJmjBRGvx6dBYugiag4iR9ZnpHNued26UTJ+BPTemTA7a4cDzseKKB6NQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-14.0.3.tgz",
+      "integrity": "sha512-xtYV5ygkfl/6JUaI99NeD1AdM4WcCrCOsx/5IR3ZohUQ1q9vPPvcArWa9QAa1GgU7HNhkgXU90yELwsOtSTc4w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@angular/material-moment-adapter": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-14.0.3.tgz",
+      "integrity": "sha512-Lf6Hug+/e3OPa6rQuvheIS2yM/Acq7fv+WsYwfo23s7xA6z5ScqsHgMZlKre8upnaFGJWMmEQbjziUVnwX8GfQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -17387,6 +17418,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "moment": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/src/assets/stack-blitz/package.json
+++ b/src/assets/stack-blitz/package.json
@@ -17,9 +17,11 @@
     "@angular/core": "~14.0.0",
     "@angular/forms": "~14.0.0",
     "@angular/material": "${version}",
+    "@angular/material-moment-adapter": "${version}",
     "@angular/platform-browser": "~14.0.0",
     "@angular/platform-browser-dynamic": "~14.0.0",
     "@angular/router": "~14.0.0",
+    "moment": "^2.18.1",
     "rxjs": "~7.4.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.5"


### PR DESCRIPTION
Adds `@angular/material-moment-adapter` and `moment` to the package.json
on stackblitz examples. This fixes the "Cannot find module 'moment' or
its corresponding type declarations." in some examples.

Fixes https://github.com/angular/components/issues/25136