### PR TITLE
fix: lighthouse check failing in v15

### DIFF
--- a/src/app/shared/navbar/navbar.scss
+++ b/src/app/shared/navbar/navbar.scss
@@ -11,6 +11,10 @@
   }
 }
 
+.mat-mdc-button-base:not(:disabled) {
+  color: inherit;
+}
+
 .flex-spacer {
   flex-grow: 1;
 }

--- a/src/app/shared/version-picker/version-picker.scss
+++ b/src/app/shared/version-picker/version-picker.scss
@@ -1,0 +1,3 @@
+.mat-mdc-button-base:not(:disabled) {
+  color: inherit;
+}

--- a/src/app/shared/version-picker/version-picker.ts
+++ b/src/app/shared/version-picker/version-picker.ts
@@ -18,6 +18,7 @@ interface VersionInfo {
 @Component({
   selector: 'version-picker',
   templateUrl: './version-picker.html',
+  styleUrls: ['./version-picker.scss']
 })
 export class VersionPicker {
   /** The currently running version of Material. */


### PR DESCRIPTION
The MDC buttons have a more specific selector for the button color which was breaking the color contrast check.