### PR TITLE
fix: add dynamic copyright

### DIFF
--- a/src/app/shared/footer/footer.html
+++ b/src/app/shared/footer/footer.html
@@ -18,7 +18,7 @@
 
     <div class="docs-footer-copyright">
       <div>
-        <span>Powered by Google LLC ©2010-2021.</span>
+        <span>Powered by Google LLC ©2010-{{year}}.</span>
         <a href="https://github.com/angular/components/blob/main/LICENSE">Code licensed under an MIT-style License.</a>
         <span>Documentation licensed under CC BY 4.0.</span>
       </div>

--- a/src/app/shared/footer/footer.ts
+++ b/src/app/shared/footer/footer.ts
@@ -9,6 +9,7 @@ import {VERSION} from '@angular/material/core';
 export class Footer {
   isNextVersion = location.hostname.startsWith('next.material.angular.io');
   version = VERSION.full;
+  year = new Date().getFullYear();
 }
 
 


### PR DESCRIPTION
Update the copyright to change it dynamically using JS, so now don't need to do a deploy just to update the footer.