### PR TITLE
test: ensure navbar.spec.ts has at least one test

### DIFF
--- a/src/app/shared/navbar/navbar.spec.ts
+++ b/src/app/shared/navbar/navbar.spec.ts
@@ -18,5 +18,9 @@ describe('NavBar', () => {
     fixture.detectChanges();
   });
 
+  it('should create components', () => {
+    expect(fixture.nativeElement).toBeTruthy();
+  });
+
   // Note: Add tests as logic is added to navbar class.
 });


### PR DESCRIPTION
Or we can exclude it but I figured it's worth just asserting it is successfully created 🤷 

For some reason having no tests within a `describe` caused the tests to fail when run from bazel. I didn't investigate at all since just adding a test seemed reasonable.