### PR TITLE
fix: harnesses not working on Stackblitz

### DIFF
--- a/src/assets/stack-blitz/src/test.ts
+++ b/src/assets/stack-blitz/src/test.ts
@@ -7,13 +7,6 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: {
-  context(path: string, deep?: boolean, filter?: RegExp): {
-    keys(): string[];
-    <T>(id: string): T;
-  };
-};
-
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
@@ -21,6 +14,10 @@ getTestBed().initTestEnvironment(
 );
 
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = (import.meta as any).webpackContext('./', {
+  recursive: true,
+  regExp: /\.spec\.ts$/
+});
+
 // And load the modules.
 context.keys().map(context);


### PR DESCRIPTION
Updates the test.ts to use the correct API for discovering the test files.

Fixes https://github.com/angular/components/issues/26806.