### PR TITLE
build: update to fix material `deploy_docs_site` CI step

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/cdk-experimental": "^16.0.0-next.4",
     "@angular/common": "^16.0.0-next.5",
     "@angular/compiler": "^16.0.0-next.5",
-    "@angular/components-examples": "https://github.com/angular/material2-docs-content.git#5f06e33d3aab6a59b1f588cbdf5425dbfdf71663",
+    "@angular/components-examples": "https://github.com/angular/material2-docs-content.git#2f63410f273e10e1539f08f1ea99a02edf6ab6b9",
     "@angular/core": "^16.0.0-next.5",
     "@angular/forms": "^16.0.0-next.5",
     "@angular/google-maps": "^16.0.0-next.4",

--- a/src/app/shared/example-viewer/example-viewer.ts
+++ b/src/app/shared/example-viewer/example-viewer.ts
@@ -197,7 +197,7 @@ export class ExampleViewer implements OnInit {
       // files. More details: https://webpack.js.org/api/module-methods/#magic-comments.
       const moduleExports: any = await import(
         /* webpackExclude: /\.map$/ */
-        '@angular/components-examples/fesm2020/' + module.importSpecifier
+        '@angular/components-examples/fesm2022/' + module.importSpecifier
       );
       this._exampleComponentType = moduleExports[componentName];
       // The components examples package is built with Ivy. This means that no factory files are

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,9 +248,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/components-examples@https://github.com/angular/material2-docs-content.git#5f06e33d3aab6a59b1f588cbdf5425dbfdf71663":
-  version "15.0.0"
-  resolved "https://github.com/angular/material2-docs-content.git#5f06e33d3aab6a59b1f588cbdf5425dbfdf71663"
+"@angular/components-examples@https://github.com/angular/material2-docs-content.git#2f63410f273e10e1539f08f1ea99a02edf6ab6b9":
+  version "16.1.0-next.0"
+  resolved "https://github.com/angular/material2-docs-content.git#2f63410f273e10e1539f08f1ea99a02edf6ab6b9"
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
This commit updates `@angular/components-examples` to the latest SHA which contains the APF version 16 changes.

See: https://github.com/angular/components/commit/44c3c527c5d8fb3a836644bbbfb38a7bcfea0bff