### PR TITLE
fix: replace use of turbo with yarn

### DIFF
--- a/src/app/shared/stack-blitz/stack-blitz-writer.ts
+++ b/src/app/shared/stack-blitz/stack-blitz-writer.ts
@@ -203,7 +203,7 @@ export class StackBlitzWriter {
         .replace(/material-docs-example/g, data.selectorName)
         .replace(/\${title}/g, data.description);
     } else if (fileName === '.stackblitzrc') {
-      fileContent = fileContent.replace(/\${startCommand}/, isTest ? 'turbo test' : 'turbo start');
+      fileContent = fileContent.replace(/\${startCommand}/, isTest ? 'yarn test' : 'yarn start');
     } else if (fileName === 'src/main.ts') {
       const mainComponentName = data.componentNames[0];
 

--- a/src/assets/stack-blitz/.stackblitzrc
+++ b/src/assets/stack-blitz/.stackblitzrc
@@ -1,7 +1,4 @@
 {
   "installDependencies": true,
-  "startCommand": "${startCommand}",
-  "env": {
-    "ENABLE_CJS_IMPORTS": true
-  }
+  "startCommand": "${startCommand}"
 }


### PR DESCRIPTION
This PR replace the use of `turbo` with `yarn` as `turbo` is being deprecated and StackBlitz has support for `yarn` v1 out of the box.

See related PR: https://github.com/angular/angular/pull/50576