### PR TITLE
fix: auto scroll is not working on devices narrower than 721px(#1219)

### DIFF
--- a/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/src/app/pages/component-sidenav/component-sidenav.scss
@@ -104,7 +104,7 @@ div.docs-component-viewer-nav-content .mat-nav-list .mat-mdc-list-item .mat-list
 
 @media (max-width: 720px) {
   .docs-component-viewer-sidenav-container {
-    flex: 1 0 auto;
+    flex: 1 0;
   }
 
   .docs-component-sidenav-body-content {


### PR DESCRIPTION
The flex-basis in the class docs-component-viewer-sidenav-container property was creating problems with the scroll bar in the page https://material.angular.io/cdk/drag-drop/examples for small devices.

Fixes https://github.com/angular/material.angular.io/issues/1219 and https://github.com/angular/components/issues/26476