### PR TITLE
fix: directly check if the hostname is the expected hostname instead of just starting with the hostname

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - browser-tools/install-chrome
       - restore_cache:
           key: *cache_key
       - *yarn_install

--- a/src/app/pages/homepage/homepage.ts
+++ b/src/app/pages/homepage/homepage.ts
@@ -40,7 +40,7 @@ export class Homepage implements OnInit {
   @HostBinding('class.main-content') readonly mainContentClass = true;
   @HostBinding('class.animations-disabled') readonly animationsDisabled: boolean;
 
-  isNextVersion = location.hostname.startsWith('next.material.angular.io');
+  isNextVersion = location.hostname === 'next.material.angular.io';
 
   constructor(
     public _componentPageTitle: ComponentPageTitle,

--- a/src/app/shared/footer/footer.ts
+++ b/src/app/shared/footer/footer.ts
@@ -8,7 +8,7 @@ import {VERSION} from '@angular/material/core';
   standalone: true
 })
 export class Footer {
-  isNextVersion = location.hostname.startsWith('next.material.angular.io');
+  isNextVersion = location.hostname === 'next.material.angular.io';
   version = VERSION.full;
   year = new Date().getFullYear();
 }

--- a/src/app/shared/navbar/navbar.ts
+++ b/src/app/shared/navbar/navbar.ts
@@ -20,7 +20,7 @@ const SECTIONS_KEYS = Object.keys(SECTIONS);
 })
 export class NavBar implements OnDestroy {
   private subscriptions = new Subscription();
-  isNextVersion = location.hostname.startsWith('next.material.angular.io');
+  isNextVersion = location.hostname === 'next.material.angular.io';
   skipLinkHref: string | null | undefined;
   skipLinkHidden = true;
 


### PR DESCRIPTION
For security's sake the entire hostname should be checked against, not just that it starts with the hostname, otherwise another domain could just include this as a subdomain