### PR TITLE
fix: remove elevation from nav bar

### DIFF
--- a/src/app/material-docs-app.html
+++ b/src/app/material-docs-app.html
@@ -1,3 +1,0 @@
-<app-cookie-popup></app-cookie-popup>
-<app-navbar class="mat-elevation-z6"></app-navbar>
-<router-outlet></router-outlet>

--- a/src/app/material-docs-app.ts
+++ b/src/app/material-docs-app.ts
@@ -10,7 +10,11 @@ import {CookiePopup} from './shared/cookie-popup/cookie-popup';
 
 @Component({
   selector: 'material-docs-app',
-  templateUrl: './material-docs-app.html',
+  template: `
+    <app-cookie-popup/>
+    <app-navbar/>
+    <router-outlet/>
+  `,
   styleUrls: ['./material-docs-app.scss'],
   encapsulation: ViewEncapsulation.None,
   standalone: true,


### PR DESCRIPTION
The nav bar wasn't meant to have an elevation, it just wasn't working prior to a fix earlier today.