### PR TITLE
docs-bug(Homepage): app-support description text reads awkwardly

### DIFF
--- a/src/app/shared/support/support.scss
+++ b/src/app/shared/support/support.scss
@@ -14,7 +14,7 @@
 
 .docs-help-support ul li {
   text-align: center;
-  flex: 0 1 200px;
+  flex: 0 1 190px;
   -moz-box-flex: 0;
 }
 


### PR DESCRIPTION
Updating the flex pixel value to 190 is the perfect solution, checked that all the screen sizes are no longer reacting awkwardly

#28372