### PR TITLE
build: restrict postinstall scripts during package installation

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -2,6 +2,6 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-1306950124
-pnpm-lock.yaml=1345633539
-yarn.lock=-2024993586
-package.json=-2093305059
+pnpm-lock.yaml=1087437730
+yarn.lock=-1043892813
+package.json=430646288

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.4.0.cjs

--- a/package.json
+++ b/package.json
@@ -102,5 +102,16 @@
     "ts-node": "^8.10.2",
     "typescript": "~5.5.2"
   },
-  "packageManager": "yarn@4.4.0"
+  "packageManager": "yarn@4.4.0",
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    },
+    "puppeteer": {
+      "built": true
+    },
+    "re2": {
+      "built": true
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,14 @@ devDependencies:
     specifier: ~5.5.2
     version: 5.5.4
 
+dependenciesMeta:
+  esbuild:
+    built: true
+  puppeteer:
+    built: true
+  re2:
+    built: true
+
 packages:
 
   /@ampproject/remapping@2.3.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12129,6 +12129,13 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:~5.5.2"
     zone.js: "npm:~0.14.10"
+  dependenciesMeta:
+    esbuild:
+      built: true
+    puppeteer:
+      built: true
+    re2:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
When performing a yarn-based package installation, only a specific group of dependencies will now have postinstall scripts executed. This not only provides additional security benefits but also reduced the amount of script execution that occurs during each install. The workspace scripts are automatically allowed and additional specific packages can be allowed as needed.