### PR TITLE
docs-bug(Theming Angular Material): table of contents misses h2 headers

### DIFF
--- a/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/src/app/shared/table-of-contents/table-of-contents.ts
@@ -118,7 +118,7 @@ export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   }
 
   addHeaders(sectionName: string, docViewerContent: HTMLElement, sectionIndex = 0) {
-    const links = Array.from(docViewerContent.querySelectorAll('h3, h4'), header => {
+    const links = Array.from(docViewerContent.querySelectorAll('h2, h3, h4'), header => {
       // remove the 'link' icon name from the inner text
       const name = (header as HTMLElement).innerText.trim().replace(/^link/, '');
       const {top} = header.getBoundingClientRect();


### PR DESCRIPTION
Fixed issue of h2 titles not being displayed in the table of contents

Fixes #29071