### PR TITLE
fix: routing path for `cdk/testing`

### DIFF
--- a/src/app/shared/documentation-items/documentation-items.ts
+++ b/src/app/shared/documentation-items/documentation-items.ts
@@ -528,7 +528,7 @@ const DOCS: { [key: string]: DocItem[] } = {
       },
     },
     {
-      id: 'test-harnesses',
+      id: 'testing',
       name: 'Component Harnesses',
       summary: 'Foundation for component test harnesses.',
       exampleSpecs: {


### PR DESCRIPTION
renames `test-harnesses` route to `testing` as entry point for `cdk/testing` is latter in packages repository, this was causing links to not work properly when redirected to a route with `test-harnesses`

---
some examples:

https://material.angular.io/components/input/api#MatNativeOptionHarness
https://material.angular.io/cdk/test-harnesses/api#TestbedHarnessEnvironment